### PR TITLE
Update links in maps. #164

### DIFF
--- a/geo/places.json
+++ b/geo/places.json
@@ -8,7 +8,7 @@
           [ 50.056,
             26.571 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2882",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2882",
           "name" : "Dayrin — ܕܝܪܝܢ",
           "desc" : "One of the islands in Beth Qaṭraye Attestation of name ܕܝܪܝܢ in the Synodicon Orientale. Attestation of names دارين and الدارين in the Kitāb al-masālik wa-l-mamālik of Abuʾl-Qāsim Ibn Khurradādhbih. Attestation of name دارين in the Kitāb al-buldān of Aḥmad b. Muḥammad al-Hamadhānī Ibn al-Faqīh.",
           "type" : "island" } },
@@ -20,7 +20,7 @@
           [ 41.3,
             36.683333 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5647",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5647",
           "name" : "Wadi Dara - ܢܗܪܐ ܕܒܝܬ ܘܫܝ",
           "desc" : "\"Joh. Eph., EH 6.26, records that the Persian army retreated to a small river after their defeat at Tella in June 582. Michael Whitby has identified this river as the Wadi Dara (also called Wadi Jarrah), a tributary of the Khabur close to Dara.\"",
           "type" : "river" } },
@@ -32,7 +32,7 @@
           [ 80.7246163,
             7.8836573 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2935",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2935",
           "name" : "Taprobane",
           "desc" : "The island of Sri Lanka off the coast of India Attestation of name طبروباني in the Kitāb al-aʿlāq al-nafīsa of Aḥmad ibn ʿUmar Ibn Rustah.",
           "type" : "island" } },
@@ -44,7 +44,7 @@
           [ 22.5,
             37.5 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2673",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2673",
           "name" : "Greece — ܗܠܐܕܐ",
           "desc" : "\"The region located at the southern end of the Balkan Peninsula.\"",
           "type" : "region" } },
@@ -56,7 +56,7 @@
           [ 22.952885,
             40.628342 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5646",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5646",
           "name" : "Thessalonica - ܬܣܠܘܢܝܩܐ",
           "desc" : "\"One of the most important Roman cities on the Balkan peninsula, Thessalonica was provincial capital of Macedonia prima and the administrative center of the whole Illyrian prefecture. Prior to the rise of Constantinople, it was even imperial capital during parts of the 4th century.\"",
           "type" : "settlement" } },
@@ -68,7 +68,7 @@
           [ 26.9624137954,
             41.5178303653 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2854",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2854",
           "name" : "Thrace — ܬܪܩܝܐ",
           "desc" : "\"A region in south-eastern Europe, Thrace was in Late Antiquity the name of both a diocese and a province.\"",
           "type" : "region" } },
@@ -80,7 +80,7 @@
           [ 40.866752,
             37.85837 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5644",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5644",
           "name" : "Sophanene - ܒܝܬ ܨܘ̈ܦܢܝܐ",
           "desc" : "\"Sophanene was the name of a region in the southern part of Armenia, not to be confused with the neighbouring Sophene.\"",
           "type" : "region" } },
@@ -92,7 +92,7 @@
           [ 15.885196,
             42.7752864 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2936",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2936",
           "name" : "Adriatic Sea",
           "desc" : "The sea between Italy and Greece Attestation of name أذريس in the Kitāb al-aʿlāq al-nafīsa of Aḥmad ibn ʿUmar Ibn Rustah.",
           "type" : "open-water" } },
@@ -104,7 +104,7 @@
           [ -2.422,
             53.826 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2937",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2937",
           "name" : "Britain",
           "desc" : "An island northwest of Europe Attestation of name برطينية in the Kitāb al-aʿlāq al-nafīsa of Aḥmad ibn ʿUmar Ibn Rustah.",
           "type" : "island" } },
@@ -116,7 +116,7 @@
           [ 56.729889,
             24.342 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2880",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2880",
           "name" : "Mazun — ܡܙܘܢ",
           "desc" : "A diocese of the southeastern Arabian Peninsula on the shores of the Persian Gulf Attestation of name ܡܙܘܢ in the Synodicon Orientale. Attestation of name ܡܙܘܢ in the Synodicon Orientale. Attestation of name ܡܙܘܢ in the Synodicon Orientale.",
           "type" : "diocese" } },
@@ -128,7 +128,7 @@
           [ 27.8346031262,
             37.8598379245 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2857",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2857",
           "name" : "Tralles — ܛܪܠܝܘ",
           "desc" : "\"An important city in Late Antiquity in the region of Caria in western Asia minor.\"",
           "type" : "settlement" } },
@@ -140,7 +140,7 @@
           [ 32.75,
             26.25 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2847",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2847",
           "name" : "Thebais — ܬܐܒܝܣ",
           "desc" : "\"One of the provinces into which Roman Egypt was subdivided, the Thebais formed the southern part of Egypt.\"",
           "type" : "region" } },
@@ -152,7 +152,7 @@
           [ 28.971944,
             41.002778 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5641",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5641",
           "name" : "Sergius and Bacchus, Church of - ܒܝܬ ܩܕܝܫܐ ܡܪܝ ܣܪܓܝܣ",
           "desc" : "\"While there is some debate as to whether Justinian started the construction of this church before or after his accession to the imperial throne in 527, it was certainly completed by the mid-530s. It was located to the south-west of the Great Palace, directly adjacent to the Hormisdas Palace. There also was a monastery which housed many miaphysite monks and clerics during the 530s and 540s.\"",
           "type" : "church" } },
@@ -164,7 +164,7 @@
           [ 39.5,
             19 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2933",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2933",
           "name" : "Red Sea",
           "desc" : "\"The sea between Egypt\/Nubia and Arabia is mentioned in Joh. Eph., EH 4.51 and 53.\"",
           "type" : "open-water" } },
@@ -176,7 +176,7 @@
           [ 47.9999999,
             12.0000001 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2932",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2932",
           "name" : "Gulf of Aden",
           "desc" : "The bay which separates the Arabian Peninsula from the Horn of Africa Attestation of name الخليج البربري in the Kitāb al-aʿlāq al-nafīsa of Aḥmad ibn ʿUmar Ibn Rustah.",
           "type" : "open-water" } },
@@ -188,7 +188,7 @@
           [ 49.9,
             26.6 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2878",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2878",
           "name" : "Ḥaṭṭa — ܚܛܐ",
           "desc" : "A diocese based in northeastern Arabia near al-Qaṭīf Attestation of name ܚܛܐ in the Synodicon Orientale.",
           "type" : "diocese" } },
@@ -200,7 +200,7 @@
           [ 31.284786,
             30.131757 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2924",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2924",
           "name" : "ʿAyn Shams",
           "desc" : "A city in Egypt Attestation of name عين شمس in the Kitāb al-aʿlāq al-nafīsa of Aḥmad ibn ʿUmar Ibn Rustah.",
           "type" : "settlement" } },
@@ -212,7 +212,7 @@
           [ 19.610106,
             44.966447 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2716",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2716",
           "name" : "Sirmium — ܣܪܡܝܘܢ",
           "desc" : "\"An important imperial residence close to the Danube in Pannonia in the 4th century, Sirmium fell to Gothic and Gepid groups in the 5th century. The Romans reconquered it in the late 560s, but it definitely fell to the Avars in the early 580s, as recorded in Joh. Eph., EH 6.32 and 33.\"",
           "type" : "settlement" } },
@@ -224,7 +224,7 @@
           [ 36.725833,
             35.903333 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5643",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5643",
           "name" : "Sirmin - ܣܪܡܝܢ",
           "desc" : "\"A village 60km southeast of Antioch. John III Scholasticus, patriarch of Constantinople 565-577, hailed from this place.\"",
           "type" : "settlement" } },
@@ -236,7 +236,7 @@
           [ 50.63348,
             26.28298 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2879",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2879",
           "name" : "Mashmahig — ܡܫܡܗܝܓ",
           "desc" : "An episcopal see on an island in Beth Qaṭraye Attestation of name ܡܫܡܗܝܓ in the Synodicon Orientale. Attestation of name ܡܝܫܡܗܓ in the Synodicon Orientale.",
           "type" : "diocese" } },
@@ -248,7 +248,7 @@
           [ 29.898889,
             31.1575 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5618",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5618",
           "name" : "Mareotis - ܡܪܝܘܛܐ",
           "desc" : "\"A district and town to the south-west of Alexandria, famous for its freshwater lake.\"",
           "type" : "region" } },
@@ -260,7 +260,7 @@
           [ 34.701983,
             36.811081 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5585",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5585",
           "name" : "Aulai - ܐܘܠܣ",
           "desc" : "\"A town in Cilicia. Joh. Eph., EH 5.4, mentions that the tritheist bishop Conon lived in a female monastery there in the mid-570s.\"",
           "type" : "settlement" } },
@@ -272,7 +272,7 @@
           [ 41.484335,
             38.026197 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5591",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5591",
           "name" : "Chlomaron - ܟܠܝܡܪ",
           "desc" : "\"Chlomaron was a Persian fortress in Armenia close to the border with the Roman Empire and adjacent to the fortress of Aphum. Joh. Eph., EH 6.34, records that Maurice failed to take this fortress during his campaign in 578.\"",
           "type" : "fortification" } },
@@ -284,7 +284,7 @@
           [ 35.28003,
             40.572478 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2573",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2573",
           "name" : "Euchaita — ܐܘܟܐܛܐ",
           "desc" : "A settlment in northern Anatolia.",
           "type" : "settlement" } },
@@ -296,7 +296,7 @@
           [ 54.349998,
             36.166666 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2995",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2995",
           "name" : "al-Dāmaghān",
           "desc" : "A large town between al-Ray and Naysābūr Attestation of name الدامغان in the Kitāb al-buldān of Aḥmad ibn Abī Yaʿqūb al-Yaʿqūbī.",
           "type" : "settlement" } },
@@ -308,7 +308,7 @@
           [ 33.0779,
             31.2116 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2765",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2765",
           "name" : "Casium — ܩܣܝܢ",
           "desc" : "\"A monastery located on the seacoast, at the border between Egypt and Syria. Joh. Eph., EH 4.33, states that Jacob Burd'oyo and several of his companions died there in summer 578 when traveling to Egypt.\"",
           "type" : "monastery" } },
@@ -320,7 +320,7 @@
           [ 39.668324,
             38.641856 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2758",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2758",
           "name" : "ܿBeth Urtaye — ܒܝܬ ܐܘܪ̈ܛܝܐ",
           "desc" : "\"A region in southern Armenia, often called Beth Urtaye in Syriac. The miaphysite bishop George, mentioned in Joh. Eph., EH 4.10, hailed from this place.\"",
           "type" : "region" } },
@@ -332,7 +332,7 @@
           [ 54.0382895,
             35.9610935 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2994",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2994",
           "name" : "Qūmis",
           "desc" : "A region between al-Ray and Naysābūr, around al-Dāmaghān Attestation of name قومس in the Kitāb al-buldān of Aḥmad ibn Abī Yaʿqūb al-Yaʿqūbī.",
           "type" : "region" } },
@@ -344,7 +344,7 @@
           [ 58.55,
             23.6 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2943",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2943",
           "name" : "Masqaṭ",
           "desc" : "A city in ʿUmān Attestation of name مسقط in the Kitāb al-aʿlāq al-nafīsa of Aḥmad ibn ʿUmar Ibn Rustah.",
           "type" : "settlement" } },
@@ -356,7 +356,7 @@
           [ 49.2343866,
             39.4192429 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2957",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2957",
           "name" : "al-Kurr",
           "desc" : "The river that runs beside Tbilisi and into the Caspian Sea Attestation of name الكر in the Kitāb al-aʿlāq al-nafīsa of Aḥmad ibn ʿUmar Ibn Rustah.",
           "type" : "river" } },
@@ -368,7 +368,7 @@
           [ 30.51684,
             39.77489 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2572",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2572",
           "name" : "Dorylaion — ܕܐܘܪܠܝܘܢ",
           "desc" : "A settlement in norther Phrygia.",
           "type" : "settlement" } },
@@ -380,7 +380,7 @@
           [ 36.911673,
             38.246013 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5584",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5584",
           "name" : "Arabissus - ܐܪܒܝܣܘܣ",
           "desc" : "\"A city in Cappadocia, it was the hometown of emperor Maurice (582-602), who embellished it with the construction of representative builidings, as is stated in Joh. Eph., EH 5.22 and 23.\"",
           "type" : "settlement" } },
@@ -392,7 +392,7 @@
           [ 46.5,
             39.5 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5625",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5625",
           "name" : "Persarmenia - ܐܪܡܢܝܐ ܪܒܬܐ ܕܦܪܣܝܐ",
           "desc" : "\"Originally an independent kingdom situated between the Roman and Sasanian Empires, Armenia was divided between the two powers in the late 4th century. Almost four-fifths came under Sasanian dominion, and this part, with Dvin as its capital, is known as Persarmenia or Sasanian Armenia. Joh. Eph., EH 2.18-22, deals with the Sasanian persecution of the Armenian Christians in the early 570s.\"",
           "type" : "region" } },
@@ -404,7 +404,7 @@
           [ 29.223869,
             40.60388 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5633",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5633",
           "name" : "Pythia - ܦܬܝܐ",
           "desc" : "\"Joh. Eph., EH 2.46, mentions that the Kathara monastery given to a group of expelled miaphysite monks from Cappadocia was close to the therms of Pythia in Bithynia. This was a very popular spa resort for people from Constantinople, including the imperial court, throughout the Byzantine period.\"",
           "type" : "settlement" } },
@@ -416,7 +416,7 @@
           [ 41.016667,
             37.783333 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5586",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5586",
           "name" : "Batman (river) - ܟܠܬ",
           "desc" : "\"The Batman, in antiquity known as Kalat in Syriac and Nymphaios in Greek, is a tributary of the Tigris. It is mentioned in Joh. Eph., EH 6.36.\"",
           "type" : "river" } },
@@ -428,7 +428,7 @@
           [ 38.721522,
             14.125005 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5579",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5579",
           "name" : "Aksum",
           "desc" : "\"A kingdom in northern Ethiopia that converted to Christianity in the early 4th century. Joh. Eph., EH 4.53, holds that the inhabitants of Aksum adhered to the doctrines of Julian of Halicarnassus in the later sixth century.\"",
           "type" : "state" } },
@@ -440,7 +440,7 @@
           [ 32.6486095674,
             36.8834754557 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2799",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2799",
           "name" : "Isauria — ܐܝܣܘܪܝܐ",
           "desc" : "\"A mountainous region of southern Anatolia known for its warlike and often rebellious population.\"",
           "type" : "region" } },
@@ -452,7 +452,7 @@
           [ 58.798373,
             36.202448 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2996",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2996",
           "name" : "Naysābūr",
           "desc" : "A city of Khurasan Attestation of name نيسابور in the Kitāb al-buldān of Aḥmad ibn Abī Yaʿqūb al-Yaʿqūbī.",
           "type" : "settlement" } },
@@ -464,7 +464,7 @@
           [ 47.439729,
             34.584336 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2983",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2983",
           "name" : "al-Dīnawar",
           "desc" : "A city between Qarmāsīn and Hamadān Attestation of name الدينور in the Kitāb al-buldān of Aḥmad ibn Abī Yaʿqūb al-Yaʿqūbī.",
           "type" : "settlement" } },
@@ -476,7 +476,7 @@
           [ 50.003811,
             36.266819 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2968",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2968",
           "name" : "Qazwīn",
           "desc" : "A city in northwestern Iran Attestation of name قزوين in the Kitāb al-buldān of Aḥmad ibn Abī Yaʿqūb al-Yaʿqūbī.",
           "type" : "settlement" } },
@@ -488,7 +488,7 @@
           [ 47.721084,
             39.57459 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2954",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2954",
           "name" : "Warthān",
           "desc" : "A city on the river al-Rass Attestation of name ورثان in the Kitāb al-buldān of Aḥmad ibn Abī Yaʿqūb al-Yaʿqūbī. Attestation of name ورثان in the Kitāb al-aʿlāq al-nafīsa of Aḥmad ibn ʿUmar Ibn Rustah.",
           "type" : "settlement" } },
@@ -500,7 +500,7 @@
           [ 39.451111,
             38.137222 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2571",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2571",
           "name" : "Abarne — ܐܒܪ̈ܢܐ",
           "desc" : "A settlement in northern Mesopotamia.",
           "type" : "settlement" } },
@@ -512,7 +512,7 @@
           [ 41.038876,
             38.263455 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5578",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5578",
           "name" : "Akbas - ܐܩܒܐ",
           "desc" : "\"Akbas was a Persian fortress on the river Batman close to Martyropolis in southern Armenia. Joh. Eph., EH 6.36, describes its capture and destruction by the Romans in 583.\"",
           "type" : "fortification" } },
@@ -524,7 +524,7 @@
           [ 30.7201762118,
             40.5628578119 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5587",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5587",
           "name" : "Bithynia - ܒܝܬܘܢܝܐ",
           "desc" : "\"A region and Roman province in north-western Asia Minor.\"",
           "type" : "region" } },
@@ -536,7 +536,7 @@
           [ 40.641398,
             38.839058 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5593",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5593",
           "name" : "Citharizon - ܩܝܬܪܝܙ",
           "desc" : "\"A fortress in the Roman part of Armenia close to Theodosiopolis and Persarmenia. Joh. Eph., EH 6.14, mentions this place.\"",
           "type" : "fortification" } },
@@ -548,7 +548,7 @@
           [ 32.884252,
             24.025031 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5626",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5626",
           "name" : "Philae - ܦܝܠܘܢ",
           "desc" : "\"Located on an island in the First Nile Cataract, Philae was a major cultic centre for the goddess Isis. Traces have been unearthed that pagan rituals took place there until the mid-5th century, yet already since the early 4th century, Philae was also an episcopal see.\"",
           "type" : "settlement" } },
@@ -560,7 +560,7 @@
           [ 35.228586,
             32.331417 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5636",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5636",
           "name" : "Samaria - ܫܡܪܝܢ",
           "desc" : "\"Situated to the north of Jerusalem, Samaria formed the core of the ancient kingdom of Israel. Its inhabitants, the Samaritans, preserved their religious customs in Late Antiquity and repeatedly revolted against the Roman Empire in the sixth century. Joh. Eph., EH 2.29, polemically establishes a connection between Samaritans and persecutors of Christians.\"",
           "type" : "region" } },
@@ -572,7 +572,7 @@
           [ 7.5,
             32.5 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/3051",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/3051",
           "name" : "Africa — ܐܦܪܝܩܐ",
           "desc" : "\"Roman Africa was centred around its capital Carthage and one of the richest and most fertile regions of the empire.\"",
           "type" : "province" } },
@@ -584,7 +584,7 @@
           [ 36.1378635,
             36.1336355 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5597",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5597",
           "name" : "Daphne - ܕܦܢܐ",
           "desc" : "\"Daphne was an opulent western suburb of Antioch. There were large residential areas and a number of important churches.\"",
           "type" : "settlement" } },
@@ -596,7 +596,7 @@
           [ 41.453009,
             38.04186 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5583",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5583",
           "name" : "Aphum - ܦܘܡ",
           "desc" : "\"Aphum was a fortification in the Roman-Persian border area in southern Armenia to the east of Martyropolis and the river Batman. Joh. Eph., EH 6.34, records that Maurice conquered it from the Persians in 578.\"",
           "type" : "fortification" } },
@@ -608,7 +608,7 @@
           [ 45.118333,
             34.186388 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2978",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2978",
           "name" : "Jalūlāʾ",
           "desc" : "A town northeast of Baghdad Attestation of name جلولاء in the Kitāb al-buldān of Aḥmad ibn Abī Yaʿqūb al-Yaʿqūbī.",
           "type" : "settlement" } },
@@ -620,7 +620,7 @@
           [ 45.038928,
             12.771651 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2944",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2944",
           "name" : "ʿAdan",
           "desc" : "A city in southern Yemen Attestation of name عدن in the Kitāb al-aʿlāq al-nafīsa of Aḥmad ibn ʿUmar Ibn Rustah.",
           "type" : "settlement" } },
@@ -632,7 +632,7 @@
           [ 70.12808435,
             29.0592303 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2950",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2950",
           "name" : "Mihrān",
           "desc" : "The Indus River in what is today Pakistan Attestation of name مهران in the Kitāb al-aʿlāq al-nafīsa of Aḥmad ibn ʿUmar Ibn Rustah.",
           "type" : "river" } },
@@ -644,7 +644,7 @@
           [ 35.75,
             39.25 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2763",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2763",
           "name" : "Cappadocia — ܩܦܘܕܩܝܐ",
           "desc" : "\"A region of central Anatolia which was subdivided in several provinces in Late Antiquity.\"",
           "type" : "region" } },
@@ -656,7 +656,7 @@
           [ 34.989663,
             31.83933 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2574",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2574",
           "name" : "Nikopolis — ܢܝܩܦܘܠܝܣ",
           "type" : "settlement" } },
       
@@ -667,7 +667,7 @@
           [ 15.0772312333,
             47.1149830333 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5596",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5596",
           "name" : "Danube - ܕܘܢܒܝܣ ܢܗܪܐ",
           "desc" : "\"A river in central and south-eastern Europe, formerly known as the Istros. Joh. Eph., EH 6.24 and 31, mentions this river.\"",
           "type" : "river" } },
@@ -679,7 +679,7 @@
           [ 28.979938,
             41.008548 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5623",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5623",
           "name" : "The Patriarchal Palace of Constantinople - ܒܝܬ ܐܦܝܣܩܦܝܘܢ",
           "desc" : "\"The residence of the patriarchs of Constantinople was adjacent to Hagia Sophia and provided direct access to the south-western corner of the church. Joh. Eph., EH 1.18-29, mentions it as the place where he and other miaphysite bishops were imprisoned and forced to accept an edict of union with the Chalcedonians.\"",
           "type" : "building" } },
@@ -691,7 +691,7 @@
           [ 29.662742,
             30.841158 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2819",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2819",
           "name" : "Mar Menas — ܡܪܝ ܡܐܢܐ",
           "desc" : "\"A monastery and pilgrimage centre about 60 km south-west of Alexandria in the Mareotis region. During the 5th and 6th centuries, the monastery developed into one of the largest monastery complexes in Egypt.\"",
           "type" : "monastery" } },
@@ -703,7 +703,7 @@
           [ 28.979938,
             41.008548 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5609",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5609",
           "name" : "Hagia Sophia (Great Church) - ܥܕܬܐ ܪܒܬܐ",
           "desc" : "\"The monumental main church of Constantinople was destroyed during the Nika riots in 532, then rebuilt by Justinian on an even greater scale. Known as the Great Church, it played a major role in imperial ceremonies throughout the Byzantine period.\"",
           "type" : "church" } },
@@ -715,7 +715,7 @@
           [ 35.231567,
             31.773417 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5621",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5621",
           "name" : "Nea Theotokos monastery - ܕܝܪܐ ܚܕܬܐ",
           "desc" : "\"The monumental complex of the Nea Church in Jerusalem, dedicated to the Mother of God, included a monastery and was founded by Justinian in 543. Joh. Eph., EH 1.32, mentions that Photius, stepson of Belisarius, was abbot of the monastery belonging to the church.\"",
           "type" : "monastery" } },
@@ -727,7 +727,7 @@
           [ 32.680833,
             15.523889 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5580",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5580",
           "name" : "Alodia",
           "desc" : "\"Alodia was a Nubian kingdom located to the south of Nobadia and Makouria. Joh.Eph., EH 4.48-53, narrates the missionary work of the miaphysite bishop Longinus there in the late 570s. In 4.53 and 55, John adds that Alodia was also known under the name Ethiopia (ܐܬܝܘܦܝܐ).\"",
           "type" : "state" } },
@@ -739,7 +739,7 @@
           [ 46.5,
             38.5 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2953",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2953",
           "name" : "al-Rass",
           "desc" : "A river flowing from near Erzerum in modern Turkey through Armenia and Adharbayjān Attestation of name الرس in the Kitāb al-aʿlāq al-nafīsa of Aḥmad ibn ʿUmar Ibn Rustah.",
           "type" : "river" } },
@@ -751,7 +751,7 @@
           [ 69.18024,
             34.521818 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2947",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2947",
           "name" : "Kābul",
           "desc" : "A city between India and Sijistān Attestation of name كابل in the Kitāb al-aʿlāq al-nafīsa of Aḥmad ibn ʿUmar Ibn Rustah.",
           "type" : "settlement" } },
@@ -763,7 +763,7 @@
           [ 50.883333,
             34.65 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2991",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2991",
           "name" : "Qumm",
           "desc" : "A city east of Hamadān and north of Ispahan Attestation of name قم in the Kitāb al-buldān of Aḥmad ibn Abī Yaʿqūb al-Yaʿqūbī.",
           "type" : "settlement" } },
@@ -775,7 +775,7 @@
           [ 27.641374,
             42.555937 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5581",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5581",
           "name" : "Anchialus - ܐܢܟܝܠܘܣ",
           "desc" : "\"Anchialus, modern Pomorie in Bulgaria, was a city in Thrace on the west coast of the Black Sea.\"",
           "type" : "settlement" } },
@@ -787,7 +787,7 @@
           [ 28.9425,
             41.0383 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5620",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5620",
           "name" : "Mary of Blachernai (church) - ܒܝܬ ܡܪܬܝ ܡܪܝܐ ܕܒܠܩܪܢܐ",
           "desc" : "\"A church in north-western Constantinople. Joh. Eph., EH 2.16, mentions a priest named Comitas who was part of the clergy of this church.\"",
           "type" : "church" } },
@@ -799,7 +799,7 @@
           [ 44.522222,
             33.094444 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2615",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2615",
           "name" : "Seleucia-Ctesiphon — ܣܠܝܩ ܘܩܛܝܣܦܘܢ",
           "desc" : "\"Located on the Tigris, south of modern Baghdad. 483. Seleucia-Ctesiphon ܬܰܪܬܝܢ ܡܕܝ̈ܢܳܢ ܕܒܰܚܕ̈ܕܐ ܣܒܝܣ̈ܢ ܘܡܶܬܩܰܪ̈ܝܳܢ ܡܕܝ̈ܢܳܬܐ ܐܶܡܐ ܕܰܡܕܝ̈ܢܬܳܐ ܕܦܳܪ̈ܣܳܝܐ ܣܰܐܣܰܐܢܳܝ̈ܐ ܠܬܰܝܡܢܳܗ̇ ܕܒܓܕܕ ܡܰܪܕܶܐ ܫܶܬ ܫܳܥܝ̈ܢ ܘܰܚܪܶܒ̈ܝ ܒܫܘܪܳܝ ܫܘܠܛܳܢܐ ܕܥܰܪ̈ܒܝܐ ܘܰܒܓܰܢܒܗܝܢ ܝܰܘܡܳܢ ܩܪܝܬܳܐ ܕܣܰܠܡܰܐܢ ܒܰܐܟ. مدينتان متصلتان سميتا بالمدائن عاصمة الفرس الساسانيين، جنوبي بغداد مسيرة ست ساعات، خربتا في صدر الفتح العربي وبجانبهما اليوم قرية سلمان باك. two connected cities. They were the capital of the Sassanids, situated about six hours journey south of Baghdad. Both these cities were destroyed at the beginning of the Arab conquest. Near their site is the present village of Salman Pak.\"",
           "type" : "diocese" } },
@@ -811,7 +811,7 @@
           [ 27.952973,
             40.971013 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5611",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5611",
           "name" : "Heraclea (Perinthus) - ܗܪܩܠܝܐ",
           "desc" : "\"Metropolis of the Late Roman province Europa in Thrace, its significance dwindled in Late Antiquity because of the rise of Constantinople which was located only 90km to the east. Joh. Eph., EH 1.9, mentions it as a place of exile for miaphysites.\"",
           "type" : "settlement" } },
@@ -823,7 +823,7 @@
           [ 41.145452,
             38.085361 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5639",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5639",
           "name" : "Semkhart - ܫܡܟܪܬ",
           "desc" : "\"According to Joh. Eph., EH 6.35, Maurice, as commander of the Roman forces in the east, erected a fortress called Semkhart next to a mountain with the same name in the Armenian region of Sophanene in the early 580s. The place is called Samocharta in the Greek sources.\"",
           "type" : "fortification" } },
@@ -835,7 +835,7 @@
           [ 30.261111,
             41.216111 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5598",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5598",
           "name" : "Daphnudium - ܕܦܢܘܕܝܢ",
           "desc" : "\"This settlement, mentioned in Joh. Eph., EH 3.8, as the place of origin of Ino Anastasia, is tentatively identified with the island of Daphnusia off the Black Sea coast of Bithynia.\"",
           "type" : "settlement" } },
@@ -847,7 +847,7 @@
           [ 28.975,
             41.003 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2793",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2793",
           "name" : "Hormisda — ܗܘܪܡܙܕܐ",
           "desc" : "\"An imperial palace in Constantinople, built in the 5th century directly to the south-west of the Great Palace.\"",
           "type" : "building" } },
@@ -859,7 +859,7 @@
           [ 48.367981,
             34.18761 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2989",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2989",
           "name" : "Nahāwand",
           "desc" : "A city south of Hamadān Attestation of name نهاوند in the Kitāb al-buldān of Aḥmad ibn Abī Yaʿqūb al-Yaʿqūbī.",
           "type" : "settlement" } },
@@ -871,7 +871,7 @@
           [ 28.040286,
             38.488314 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5638",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5638",
           "name" : "Sardis - ܣܪܕܐ",
           "desc" : "\"The capital of Lydia, Sardis was one of the most important cities in Asia Minor throughout Antiquity and into the Byzantine period.\"",
           "type" : "settlement" } },
@@ -883,7 +883,7 @@
           [ 28.876487,
             40.976033 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5610",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5610",
           "name" : "Hebdomon - ܐܒܕܡܘܢ",
           "desc" : "\"The Hebdomon was a coastal suburb located seven miles to the west of Constantinople. In Late Antiquity, it possessed an important imperial residence and large parade grounds for the army, hence it was also referred to in Greek as πρόκενσον (prokenson). Emperors were, upon their accession, acclaimed by the army on the parade ground of the Hebdomon in the later fourth and fifth centuries.\"",
           "type" : "settlement" } },
@@ -895,7 +895,7 @@
           [ 47.5,
             32.5 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2974",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2974",
           "name" : "Mihrijānqadhaq",
           "desc" : "A region around al-Ṣaymara in western Iran Attestation of name مهرجانقذق in the Kitāb al-buldān of Aḥmad ibn Abī Yaʿqūb al-Yaʿqūbī.",
           "type" : "region" } },
@@ -907,7 +907,7 @@
           [ 27.5,
             37.5 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2747",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2747",
           "name" : "Asia — ܐܣܝܐ",
           "desc" : "\"A civil diocese in the western part of Anatolia, also the name of a Roman province.\"",
           "type" : "region" } },
@@ -919,7 +919,7 @@
           [ 86.51155633,
             25.621435 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2949",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2949",
           "name" : "Ganges",
           "desc" : "A river in northern and northeastern India Attestation of name كنك in the Kitāb al-aʿlāq al-nafīsa of Aḥmad ibn ʿUmar Ibn Rustah.",
           "type" : "river" } },
@@ -931,7 +931,7 @@
           [ 28.9771394,
             41.0064179667 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5607",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5607",
           "name" : "Great Palace of Constantinople - ܦܠܛܝܢ",
           "desc" : "\"The Great Palace was the residential complex of the East Roman emperors throughout Late Antiquity. Located at the south-eastern end of Constantinople, it consisted of several palaces and witnessed continuous building activity.\"",
           "type" : "building" } },
@@ -943,7 +943,7 @@
           [ 30.7425,
             18.224444 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5617",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5617",
           "name" : "Makouria",
           "desc" : "\"A kingdom located in Nubia, situated between the kingdoms of Nobadia and Alodia. Joh. Eph., EH 4.51 and 53, speaks of the people of Makouria.\"",
           "type" : "state" } },
@@ -955,7 +955,7 @@
           [ 36.73369977389633,
             36.13024487311365 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5575",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5575",
           "name" : "Bassos, Monastery of Mar - ܕܝܪܐ ܕܡܪܝ ܒܣ",
           "desc" : "\"This monastery was located in north-western Syria, about 30 km from Chalcis. The miaphysite bishop John of Chalcis probably resided there, as is recorded in Joh. Eph., EH 4.10.\"",
           "type" : "monastery" } },
@@ -967,7 +967,7 @@
           [ 44.5,
             33.5 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2959",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2959",
           "name" : "al-Nahrawān",
           "desc" : "A river in eastern Iraq Attestation of name النهروان in the Kitāb al-aʿlāq al-nafīsa of Aḥmad ibn ʿUmar Ibn Rustah.",
           "type" : "river" } },
@@ -979,7 +979,7 @@
           [ 28.7237779096,
             37.7085832624 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2742",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2742",
           "name" : "Aphrodisias — ܐܦܪܘܕܝܣܝܕܐ",
           "desc" : "\"The metropolis of the province of Caria in south-western Anatolia.\"",
           "type" : "settlement" } },
@@ -991,7 +991,7 @@
           [ 51.447163,
             35.594267 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2970",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2970",
           "name" : "al-Ray",
           "desc" : "A city in northern Iran Attestation of name الري in the Kitāb al-buldān of Aḥmad ibn Abī Yaʿqūb al-Yaʿqūbī.",
           "type" : "settlement" } },
@@ -1003,7 +1003,7 @@
           [ 48.5,
             37.5 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2958",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2958",
           "name" : "al-Daylam",
           "desc" : "A region in northern Iran Attestation of name الديلم in the Kitāb al-buldān of Aḥmad ibn Abī Yaʿqūb al-Yaʿqūbī. Attestation of name الديلم in the Kitāb al-aʿlāq al-nafīsa of Aḥmad ibn ʿUmar Ibn Rustah.",
           "type" : "region" } },
@@ -1015,7 +1015,7 @@
           [ 40.25866,
             37.329794 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5574",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5574",
           "name" : "Tell Beshme - ܬܠܒܫܡܐ",
           "desc" : "\"A town in Roman Mesopotamia. Its surroundings were pillaged by the Persians under Adarmahan in the 570s, as recorded in Joh. Eph., EH 6.13.\"",
           "type" : "settlement" } },
@@ -1027,7 +1027,7 @@
           [ 44.58079045,
             40.01185995 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5602",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5602",
           "name" : "Dvin - ܕܐܘܝܢ",
           "desc" : "\"Founded in the 4th century, Dvin was the capital of Armenia. After the loss of the Armenian independence and the partition of the region between Rome and the Sasanian Empire, Dvin became the residence of the Sasanian governor of Persarmenia. Joh. Eph., EH 2.18-22, deals with the Sasanian persecution of the Armenian Christians that took place there in the early 570s.\"",
           "type" : "settlement" } },
@@ -1039,7 +1039,7 @@
           [ 26.473596095,
             30.8892199489 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2810",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2810",
           "name" : "Libya — ܠܘܒܐ",
           "desc" : "\"The region of northern Africa to the east of Egypt, including the Cyrenaica.\"",
           "type" : "region" } },
@@ -1051,7 +1051,7 @@
           [ 27.1973335804,
             36.9917589062 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5628",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5628",
           "name" : "Plateia - ܦܠܛܝܐ",
           "desc" : "\"The modern Yassiada, in Greek called Plate or Plateia. This is one of the Princes' Islands close to Constantinople where recalcitrant clerics were frequently sent into exile in Late Antiquity and the Byzantine period. Joh. Eph., EH 1.16, notes that the miaphysite bishop Stephen of Cyprus was maltreated there.\"",
           "type" : "island" } },
@@ -1063,7 +1063,7 @@
           [ 28.9746077,
             41.005444 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5614",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5614",
           "name" : "Hippodrome of Constantinople - ܐܦܝܩܘܣ",
           "desc" : "\"The great hippodrome of Constantinople was situated directly adjacent to the imperial palace. This was one of the few places where the people could interact with the emperor via acclamations.\"",
           "type" : "building" } },
@@ -1075,7 +1075,7 @@
           [ 55.1454375,
             37.232558 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2972",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2972",
           "name" : "Jurjān",
           "desc" : "A city between Tabaristan and Khurasan Attestation of name جرجان in the Kitāb al-buldān of Aḥmad ibn Abī Yaʿqūb al-Yaʿqūbī.",
           "type" : "settlement" } },
@@ -1087,7 +1087,7 @@
           [ 57.068581,
             30.273015 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2999",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2999",
           "name" : "Kirmān",
           "desc" : "A city in southeastern Iran Attestation of name كرمان in the Kitāb al-buldān of Aḥmad ibn Abī Yaʿqūb al-Yaʿqūbī.",
           "type" : "settlement" } },
@@ -1099,7 +1099,7 @@
           [ 37.8712745,
             28.5482213 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2740",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2740",
           "name" : "Antioch in Caria — ܐܢܛܝܘܟ ܕܩܪܝܐܐ",
           "desc" : "\"A city in Caria in south-western Anatolia, also known as Antioch on the Maeander. John of Ephesus, EH 1.14 records that Paul of Aphrodisias was made bishop there after embracing the council of Chalcedon.\"",
           "type" : "settlement" } },
@@ -1111,7 +1111,7 @@
           [ 46.5,
             33.5 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2973",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2973",
           "name" : "Māsabadhān",
           "desc" : "A region near Mihrijānqadhaq Attestation of name ماسبذان in the Kitāb al-buldān of Aḥmad ibn Abī Yaʿqūb al-Yaʿqūbī.",
           "type" : "region" } },
@@ -1123,7 +1123,7 @@
           [ 29.082797,
             41.106759 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5577",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5577",
           "name" : "Acoemetae, Monastery of the - ܕܝܪܐ ܕܐܩܝܡܛܘܢ",
           "desc" : "\"Famous for their perpetual worship, the movement of the Acoemetae (sleepless monks), founded at the start of the 5th century, eventually settled in a monastery on the Asian side of the Bosphorus. The monks were staunchly dyophysite, to such an extent that they were suspected of harbouring Nestorian sympathies and condemned in the early 530s. Nevertheless, their monastery remained important and served as a place of imprisonment for miaphysite clerics, as is mentioned in Joh. Eph., EH 1.17.\"",
           "type" : "monastery" } },
@@ -1135,7 +1135,7 @@
           [ 80,
             -20 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2929",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2929",
           "name" : "Indian Ocean",
           "desc" : "The ocean bordering East Africa, South Asia, and Australia Attestation of name بحر الهند وفارس والصين in the Kitāb al-aʿlāq al-nafīsa of Aḥmad ibn ʿUmar Ibn Rustah.",
           "type" : "open-water" } },
@@ -1147,7 +1147,7 @@
           [ 49.9,
             26.6 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2901",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2901",
           "name" : "Ḥaṭṭa",
           "desc" : "A town in northeastern Arabia near al-Qaṭīf Attestation of name الخط in the Kitāb al-masālik wa-l-mamālik of Abuʾl-Qāsim Ibn Khurradādhbih. Attestation of name الخط in the Kitāb al-buldān of Aḥmad b. Muḥammad al-Hamadhānī Ibn al-Faqīh.",
           "type" : "settlement" } },
@@ -1159,7 +1159,7 @@
           [ 4.518428,
             52.150265 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/3028",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/3028",
           "name" : "Leiden",
           "desc" : "A city in the Netherlands",
           "type" : "settlement" } },
@@ -1171,7 +1171,7 @@
           [ 48.726603,
             26.877823 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2877",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2877",
           "name" : "Hagar — ܗܓܪ",
           "desc" : "A diocese in northeastern Arabia Attestation of name ܗܓܪ in the Synodicon Orientale.",
           "type" : "diocese" } },
@@ -1183,7 +1183,7 @@
           [ 48.726603,
             26.877823 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2903",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2903",
           "name" : "Hagar",
           "desc" : "A town in northeastern Arabia Attestation of name هجر in the Kitāb al-masālik wa-l-mamālik of Abuʾl-Qāsim Ibn Khurradādhbih. Attestation of name هجر in the Kitāb al-buldān of Aḥmad b. Muḥammad al-Hamadhānī Ibn al-Faqīh.",
           "type" : "settlement" } },
@@ -1195,7 +1195,7 @@
           [ 50.056,
             26.571 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2902",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2902",
           "name" : "Hagar and Pīṭ Ardashīr — ܗܓܪ ܘܦܝܛܐܪܕܫܝܪ",
           "desc" : "A diocese in northeastern Arabia near al-Qaṭīf Attestation of name ܗܓܪ ܘܦܝܛܐܪܕܫܝܪ in the Synodicon Orientale.",
           "type" : "diocese" } },
@@ -1207,7 +1207,7 @@
           [ 49.983804,
             26.612985 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/3013",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/3013",
           "name" : "al-Qaṭīf",
           "desc" : "One of the largest cities in the region of al-Baḥrayn Attestation of name القطيف in the Kitāb al-masālik wa-l-mamālik of Abuʾl-Qāsim Ibn Khurradādhbih. Attestation of name القطيف in the Kitāb al-buldān of Aḥmad b. Muḥammad al-Hamadhānī Ibn al-Faqīh.",
           "type" : "settlement" } },
@@ -1219,7 +1219,7 @@
           [ 39.815421,
             21.426804 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2906",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2906",
           "name" : "Mecca",
           "desc" : "A city in Arabia, regarded by Muslims as the holiest city Attestation of name مكة in the Kitāb al-buldān of Aḥmad ibn Abī Yaʿqūb al-Yaʿqūbī. Attestation of name مكّة in the Kitāb al-aʿlāq al-nafīsa of Aḥmad ibn ʿUmar Ibn Rustah.",
           "type" : "settlement" } },
@@ -1231,7 +1231,7 @@
           [ 28.975833,
             41.006389 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5649",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/5649",
           "name" : "Zeuxippus, Baths of - ܙܘܩܣܦܘܣ",
           "desc" : "\"Situated very close to the Great Palace, Hagia Sophia and the hippodrome, the baths of Zeuxippus were the most famous public baths of Constantinople. Throughout Late Antiquity, emperors brought statues and other renowned works of art to Constantinople, many of which were put on display in the baths of Zeuxippus. The baths were burned down in 532 during the Nika riots and rebuilt by Justinian I. Joh. Eph., EH 3.24, refers to the eastern part of the city near the seashore by the name Zeuxippus, likely because of the prominence of the baths.\"",
           "type" : "building" } },
@@ -1243,7 +1243,7 @@
           [ 40.7291755,
             47.5437096 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2938",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2938",
           "name" : "Don River",
           "desc" : "A river that flows into the Black Sea from the north Attestation of name طانيس in the Kitāb al-aʿlāq al-nafīsa of Aḥmad ibn ʿUmar Ibn Rustah.",
           "type" : "river" } },
@@ -1255,7 +1255,7 @@
           [ 50.214444,
             25.643056 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/3005",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/3005",
           "name" : "al-ʿUqayr",
           "desc" : "A coastal village near Hagar in al-Baḥrayn Attestation of name العقير in the Kitāb al-masālik wa-l-mamālik of Abuʾl-Qāsim Ibn Khurradādhbih.",
           "type" : "settlement" } },
@@ -1267,7 +1267,7 @@
           [ 22.8799302264,
             37.9072987541 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2657",
+        { "uri" : "http:\/\/dev.syriaca.org\/place\/2657",
           "name" : "Corinth — ܩܘܪܝܢܬܘܣ",
           "desc" : "\"Located at the entrance to the Peloponnese, Corinth was the metropolis of the Roman province of Achaea.\"",
           "type" : "settlement" } } ] }

--- a/johnofephesus/places/places.json
+++ b/johnofephesus/places/places.json
@@ -9,7 +9,7 @@
           [ 41.3,
             36.683333 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5647",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5647",
           "name" : "Wadi Dara - ܢܗܪܐ ܕܒܝܬ ܘܫܝ",
           "desc" : "\"Joh. Eph., EH 6.26, records that the Persian army retreated to a small river after their defeat at Tella in June 582. Michael Whitby has identified this river as the Wadi Dara (also called Wadi Jarrah), a tributary of the Khabur close to Dara.\"",
           "type" : "river" } },
@@ -21,7 +21,7 @@
           [ 29.904133,
             31.195371 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/572",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/572",
           "name" : "Alexandria — ܐܠܟܣܢܕܪܝܐ",
           "desc" : "A city in Egypt. Attestation of name الاسكندرية in the Muʿjam al-buldān of Yāqūt al-Ḥamawī. Egypt",
           "type" : "settlement" } },
@@ -33,7 +33,7 @@
           [ 36.5348059738,
             32.7335787681 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/214",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/214",
           "name" : "Ḥawrān — ܚܘܪܢ",
           "desc" : "\"Hawran, also called Haurin, is a mountainous region in southern Syria. Joh. Eph., EH 3.40, mentions that Magnus, an official who held high ranks under Justin II and Tiberius, was a native of this region.\"",
           "type" : "region" } },
@@ -45,7 +45,7 @@
           [ 39.766666,
             37.233333 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/200",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/200",
           "name" : "Tella — ܬܠܐ",
           "desc" : "\"ܡܕܝܺܢܬܐ ܗܘܳܬ ܡܫܰܟܠܠܬܐ ܕܒܶܝܬ ܡܰܪܕܝܢ ܠܐܘܪܗܳܝ ܡܰܪܕܶܐ ܬܪܶܝܢ ܡܰܫ̈ܩܠܝܢ ܡܶܢ ܩܰܕܡܳܝܬܐ ܘܝܰܘܡܳܢ ܡܕܝܢܬܽܘܢܳܝܬܳܐ ܗܝ ܕܡܶܬܶܐܡܰܪ ܠܗ̇ ܘܶܝܪܰܐܢܫܰܗܝܪ. كانت مدينة عامرة بين ماردين والرها مسافة مرحلتين عن الاولى. وهي اليوم بليدة يقال لها ويران شهر once a flourishing town between Mardin and Edessa, about two leagues from Mardin. Today it is a small village called Wayran Shahr.\"",
           "type" : "settlement" } },
@@ -57,7 +57,7 @@
           [ 22.5,
             37.5 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2673",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/2673",
           "name" : "Greece — ܗܠܐܕܐ",
           "desc" : "\"The region located at the southern end of the Balkan Peninsula.\"",
           "type" : "region" } },
@@ -69,7 +69,7 @@
           [ 22.952885,
             40.628342 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5646",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5646",
           "name" : "Thessalonica - ܬܣܠܘܢܝܩܐ",
           "desc" : "\"One of the most important Roman cities on the Balkan peninsula, Thessalonica was provincial capital of Macedonia prima and the administrative center of the whole Illyrian prefecture. Prior to the rise of Constantinople, it was even imperial capital during parts of the 4th century.\"",
           "type" : "settlement" } },
@@ -81,7 +81,7 @@
           [ 26.9624137954,
             41.5178303653 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2854",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/2854",
           "name" : "Thrace — ܬܪܩܝܐ",
           "desc" : "\"A region in south-eastern Europe, Thrace was in Late Antiquity the name of both a diocese and a province.\"",
           "type" : "region" } },
@@ -93,7 +93,7 @@
           [ 40.866752,
             37.85837 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5644",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5644",
           "name" : "Sophanene - ܒܝܬ ܨܘ̈ܦܢܝܐ",
           "desc" : "\"Sophanene was the name of a region in the southern part of Armenia, not to be confused with the neighbouring Sophene.\"",
           "type" : "region" } },
@@ -105,7 +105,7 @@
           [ 35.48333,
             38.73333 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/60",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/60",
           "name" : "Caesarea — ܩܣܪܝܐ",
           "desc" : "\"ܡܕܝܢܬܳܐ ܗܝ ܕܰܒܬܰܝܡܢܳܐ ܡܰܕܢܚܳܝܐ ܕܰܐܢܩܘܪܰܐ ܘܡܶܬܩܰܪܝܳܐ ܝܰܘܡܳܢ ܩܰܝܣܰܪ. مدينة في الجنوب الشرقي من انقرة تعرف الآن بقيسر. a town southeast of Ankara, known today as Kayseri.\"",
           "type" : "settlement" } },
@@ -117,7 +117,7 @@
           [ 39.033889,
             36.8775 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/216",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/216",
           "name" : "Ḥarran — ܚܪܢ",
           "desc" : "\"Syr.\/Hebrew Ḥārān; Latin Carrhae; Arabic Ḥarran. Ancient city in Mesopotamia, approximately 45 km south-southeast of Edessa. 250. Ḥarran ܡܕܺܝܢܬܳܐ ܗܘܳܬ ܪܰܒܬܳܐ ܘܥܰܬܝܩܬܳܐ ܕܰܒܬܰܝܡܢܗ̇ ܕܐܽܘܪܗܳܝ ܘܰܚܫܝܒܳܐ ܗܘܳܬ ܪܒܐ ܕܐܰܬܪ̈ܘܳܬܐ ܕܡܨܪ ܘܰܩܪܝܬܳܐ ܗܝ ܗܳܫܐ. كانت مدينة عظيمة قديمة في جنوبي الرها و بينهما يوم وعُدّت قصبة ديار مضر وامست قرية once a great city, a day’s journey south from Edessa. It was considered the capital of Diyar Miṣr, but now is a small village.\"",
           "type" : "settlement" } },
@@ -129,7 +129,7 @@
           [ 27.8346031262,
             37.8598379245 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2857",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/2857",
           "name" : "Tralles — ܛܪܠܝܘ",
           "desc" : "\"An important city in Late Antiquity in the region of Caria in western Asia minor.\"",
           "type" : "settlement" } },
@@ -141,7 +141,7 @@
           [ 32.75,
             26.25 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2847",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/2847",
           "name" : "Thebais — ܬܐܒܝܣ",
           "desc" : "\"One of the provinces into which Roman Egypt was subdivided, the Thebais formed the southern part of Egypt.\"",
           "type" : "region" } },
@@ -153,7 +153,7 @@
           [ 28.971944,
             41.002778 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5641",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5641",
           "name" : "Sergius and Bacchus, Church of - ܒܝܬ ܩܕܝܫܐ ܡܪܝ ܣܪܓܝܣ",
           "desc" : "\"While there is some debate as to whether Justinian started the construction of this church before or after his accession to the imperial throne in 527, it was certainly completed by the mid-530s. It was located to the south-west of the Great Palace, directly adjacent to the Hormisdas Palace. There also was a monastery which housed many miaphysite monks and clerics during the 530s and 540s.\"",
           "type" : "church" } },
@@ -165,7 +165,7 @@
           [ 39.5,
             19 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2933",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/2933",
           "name" : "Red Sea",
           "desc" : "\"The sea between Egypt\/Nubia and Arabia is mentioned in Joh. Eph., EH 4.51 and 53.\"",
           "type" : "open-water" } },
@@ -177,7 +177,7 @@
           [ 44.5812226667,
             33.094703 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/58",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/58",
           "name" : "Ctesiphon — ܩܛܝܣܦܘܢ",
           "desc" : "\"Located on the Tigris, south of modern Baghdad. Ctesiphon was the imperial capital of the Sasanian Empire. Joh. Eph., EH 3.40 and 6.10 does not use the name Ctesiphon, but refers to it as the 'royal city'. 483. Seleucia-Ctesiphon ܬܰܪܬܝܢ ܡܕܝ̈ܢܳܢ ܕܒܰܚܕ̈ܕܐ ܣܒܝܣ̈ܢ ܘܡܶܬܩܰܪ̈ܝܳܢ ܡܕܝ̈ܢܳܬܐ ܐܶܡܐ ܕܰܡܕܝ̈ܢܬܳܐ ܕܦܳܪ̈ܣܳܝܐ ܣܰܐܣܰܐܢܳܝ̈ܐ ܠܬܰܝܡܢܳܗ̇ ܕܒܓܕܕ ܡܰܪܕܶܐ ܫܶܬ ܫܳܥܝ̈ܢ ܘܰܚܪܶܒ̈ܝ ܒܫܘܪܳܝ ܫܘܠܛܳܢܐ ܕܥܰܪ̈ܒܝܐ ܘܰܒܓܰܢܒܗܝܢ ܝܰܘܡܳܢ ܩܪܝܬܳܐ ܕܣܰܠܡܰܐܢ ܒܰܐܟ. مدينتان متصلتان سميتا بالمدائن عاصمة الفرس الساسانيين، جنوبي بغداد مسيرة ست ساعات، خربتا في صدر الفتح العربي وبجانبهما اليوم قرية سلمان باك. two connected cities. They were the capital of the Sassanids, situated about six hours journey south of Baghdad. Both these cities were destroyed at the beginning of the Arab conquest. Near their site is the present village of Salman Pak.\"",
           "type" : "settlement" } },
@@ -189,7 +189,7 @@
           [ 38.75,
             35.616667 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/165",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/165",
           "name" : "Sergiopolis",
           "desc" : "\"The city of Rusafa in the Syrian desert became known as Sergiopolis in Late Antiquity because of the martyr Sergius. Joh. Eph., EH 6.4 refers to it under its former name Rusafa.\"",
           "type" : "settlement" } },
@@ -201,7 +201,7 @@
           [ 40.210556,
             37.981944 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/8",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/8",
           "name" : "Amida — ܐܡܝܕ",
           "desc" : "\"City in upper Mesopotamia. 32. Amid ܡܕܺܝܢܬܐ ܚܰܣܝ̣ܢܬܐ ܕܕܶܩܠܰܬ ܚܳܕܰܪ ܠܣܘܓܐܗ̇. مدينة قديمة حصينة دجلة محيطة باكثرها an ancient fortified city, virtually surrounded by the Tigris.\"",
           "type" : "settlement" } },
@@ -213,7 +213,7 @@
           [ 36.2038547331,
             34.0063794317 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/577",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/577",
           "name" : "Baʿalbak",
           "desc" : "\"The city of Heliopolis, in Syriac-Armaic known as Baalbek, housed one of the largest pagan cult centres in the eastern Mediterranean. Among late antique Christian authors, it was famous for the obstinacy with which the majority of the inhabitants clung to pagan rites. For instance, Joh. Eph., EH 3.27 mentions the dispatch of the imperial official Theophilus in 579\/80 to lead an investigation against pagans in the city.\"",
           "type" : "settlement" } },
@@ -225,7 +225,7 @@
           [ 33.921682,
             28.58771 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/563",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/563",
           "name" : "Mount Sinai — ܛܘܪܐ ܕܣܝܢܝ",
           "desc" : "\"An important Christian pilgrimage site in late antiquity as it was believed to be the place where Moses received the ten commandments from God. Justinian erected a fortified monastic complex between 548 and 565. Gregory, patriarch of Antioch from 570 to 592, was archimandrite of this monastery prior to his accession as patriarch.\"",
           "type" : "mountain" } },
@@ -237,7 +237,7 @@
           [ 19.610106,
             44.966447 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2716",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/2716",
           "name" : "Sirmium — ܣܪܡܝܘܢ",
           "desc" : "\"An important imperial residence close to the Danube in Pannonia in the 4th century, Sirmium fell to Gothic and Gepid groups in the 5th century. The Romans reconquered it in the late 560s, but it definitely fell to the Avars in the early 580s, as recorded in Joh. Eph., EH 6.32 and 33.\"",
           "type" : "settlement" } },
@@ -249,7 +249,7 @@
           [ 36.725833,
             35.903333 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5643",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5643",
           "name" : "Sirmin - ܣܪܡܝܢ",
           "desc" : "\"A village 60km southeast of Antioch. John III Scholasticus, patriarch of Constantinople 565-577, hailed from this place.\"",
           "type" : "settlement" } },
@@ -261,7 +261,7 @@
           [ 40.948011,
             37.1783845 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/67",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/67",
           "name" : "Dara — ܕܪܐ",
           "desc" : "\"Located in Roman Mesopotamia close to the Persian border, Dara was built by the emperor Anastasius in the early 6th century as a fortress city to confront the Persian stronghold of Nisibis. The fall of the city to the Persians in 573 reportedly triggered Justin's lapse into madness. The Persian siege of the city is described in Joh. Eph., EH 6.5. ܡܕܝܺܢܬܐ ܗܝ ܕܒܰܦܫܦܘܽܠܐ ܕܛܘܪܐ ܒܶܝܬ ܢܨܺܝܒܝܺܢ ܠܡܰܪܕܺܝܢ ܐܶܬܝܰܬܒܰܬ ܫܢܰܬ 506 ܘܩܰܘܝܰܬ ܟܘܪܣܝܳܐ ܐܶܦܝܣܩܘܦܳܝܐ ܠܣܘܪ̈ܝܳܝܐ ܥܕܡܐ ܠܡܶܨܥܝ̈ܬܗ ܕܕܳܪܳܐ ܕܝ̄ܒ ܘܝܰܘܡܳܢ ܩܪܺܝܬܳܐ ܗܝ ܙܥܘܽܪܬܐ. بلدة في لحف جبل بين نصيبين وماردين مُصّرت عام 506م وظلت كرسيا اسقفيا للسريان حتى اواسط المئة الثانية عشرة وهي اليوم قرية حقيرة a town situated at the foot of the mountain between Nisibin and Mardin. Built in 506, it remained a seat of Syrian bishops until the middle of the twelfth century. Today it is an insignificant village.\"",
           "type" : "settlement" } },
@@ -273,7 +273,7 @@
           [ 40.04962,
             36.82584 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/172",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/172",
           "name" : "Reshʿayna — ܪܝܫ ܥܝܢܐ",
           "desc" : "\"City on the Khabur, located in the eastern part of ancient Osrhoene and today straddling the Turkish-Syrian border, the Syrian part now bearing the name Raʾs al-ʿAyn and the Turkish part Ceylanpınar (earlier Resülayn). 455. Reshʿayna ܡܕܝܢܬܳܐ ܗܝ ܥܰܠ ܢܗܰܪ ܚܳܒܘܪ ܒܓܳܙܰܪܬܐ ܒܕܳܪܐ ܕܰܬܠܳܬܰܥܣܪ ܥܰܡܝܪܐ ܗܘܳܬ ܟܶܢ ܚܶܪܒܰܬ ܘܒܰܫܢܰܬ 1869 ܥܡܰܪܘ ܒܗ ܚܰܕ ܛܘܗܡܳܐ ܕܰܓܙܝܪ. ܟܶܢ ܐܶܬܘ ܠܗ̇ ܣܘܪ̈ܝܳܝܐ ܘܐܰܪ̈ܡܢܳܝܐ ܘܰܥܡܰܪܘ ܒܗ̇ ܘܐܝܬ ܠܗܘܢ ܒܗ̇ ܬܰܪܬܶܝܢ ܥܕ̈ܬܳܐ. بلدة على منابع نهر الخابور في الجزيرة كانت عامرة في المئة الثالثة عشرة ثم جربت وسنة 1869 توطنتها عشيره من الجركس، ثم سكنها خلق من السريان والارمن ولهم فيها بيعتان. a town located at the source of the river Khabur in the Jazira. It was settled in the thirteenth century, but was laid waste in 1869. It was later resettled by a Circassian tribe and then by Syrians and Armenians, who built churches in it.\"",
           "type" : "settlement" } },
@@ -285,7 +285,7 @@
           [ 41.5,
             38.5 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/673",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/673",
           "name" : "Arzanene",
           "desc" : "A region west and a bit south of Lake Van. Armenia",
           "type" : "region" } },
@@ -297,7 +297,7 @@
           [ 34.75,
             31.25 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/698",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/698",
           "name" : "Filasṭīn — ܦܠܫܬ",
           "desc" : "\"A region in the southern Levant, in Late Antiquity subdivided in several provinces also called Palestine.\"",
           "type" : "region" } },
@@ -309,7 +309,7 @@
           [ 29.898889,
             31.1575 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5618",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5618",
           "name" : "Mareotis - ܡܪܝܘܛܐ",
           "desc" : "\"A district and town to the south-west of Alexandria, famous for its freshwater lake.\"",
           "type" : "region" } },
@@ -321,7 +321,7 @@
           [ 34.701983,
             36.811081 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5585",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5585",
           "name" : "Aulai - ܐܘܠܣ",
           "desc" : "\"A town in Cilicia. Joh. Eph., EH 5.4, mentions that the tritheist bishop Conon lived in a female monastery there in the mid-570s.\"",
           "type" : "settlement" } },
@@ -333,7 +333,7 @@
           [ 41.484335,
             38.026197 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5591",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5591",
           "name" : "Chlomaron - ܟܠܝܡܪ",
           "desc" : "\"Chlomaron was a Persian fortress in Armenia close to the border with the Roman Empire and adjacent to the fortress of Aphum. Joh. Eph., EH 6.34, records that Maurice failed to take this fortress during his campaign in 578.\"",
           "type" : "fortification" } },
@@ -345,7 +345,7 @@
           [ 33.0779,
             31.2116 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2765",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/2765",
           "name" : "Casium — ܩܣܝܢ",
           "desc" : "\"A monastery located on the seacoast, at the border between Egypt and Syria. Joh. Eph., EH 4.33, states that Jacob Burd'oyo and several of his companions died there in summer 578 when traveling to Egypt.\"",
           "type" : "monastery" } },
@@ -357,7 +357,7 @@
           [ 39.668324,
             38.641856 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2758",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/2758",
           "name" : "ܿBeth Urtaye — ܒܝܬ ܐܘܪ̈ܛܝܐ",
           "desc" : "\"A region in southern Armenia, often called Beth Urtaye in Syriac. The miaphysite bishop George, mentioned in Joh. Eph., EH 4.10, hailed from this place.\"",
           "type" : "region" } },
@@ -369,7 +369,7 @@
           [ 36.911673,
             38.246013 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5584",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5584",
           "name" : "Arabissus - ܐܪܒܝܣܘܣ",
           "desc" : "\"A city in Cappadocia, it was the hometown of emperor Maurice (582-602), who embellished it with the construction of representative builidings, as is stated in Joh. Eph., EH 5.22 and 23.\"",
           "type" : "settlement" } },
@@ -381,7 +381,7 @@
           [ 46.5,
             39.5 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5625",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5625",
           "name" : "Persarmenia - ܐܪܡܢܝܐ ܪܒܬܐ ܕܦܪܣܝܐ",
           "desc" : "\"Originally an independent kingdom situated between the Roman and Sasanian Empires, Armenia was divided between the two powers in the late 4th century. Almost four-fifths came under Sasanian dominion, and this part, with Dvin as its capital, is known as Persarmenia or Sasanian Armenia. Joh. Eph., EH 2.18-22, deals with the Sasanian persecution of the Armenian Christians in the early 570s.\"",
           "type" : "region" } },
@@ -393,7 +393,7 @@
           [ 29.223869,
             40.60388 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5633",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5633",
           "name" : "Pythia - ܦܬܝܐ",
           "desc" : "\"Joh. Eph., EH 2.46, mentions that the Kathara monastery given to a group of expelled miaphysite monks from Cappadocia was close to the therms of Pythia in Bithynia. This was a very popular spa resort for people from Constantinople, including the imperial court, throughout the Byzantine period.\"",
           "type" : "settlement" } },
@@ -405,7 +405,7 @@
           [ 41.016667,
             37.783333 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5586",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5586",
           "name" : "Batman (river) - ܟܠܬ",
           "desc" : "\"The Batman, in antiquity known as Kalat in Syriac and Nymphaios in Greek, is a tributary of the Tigris. It is mentioned in Joh. Eph., EH 6.36.\"",
           "type" : "river" } },
@@ -417,7 +417,7 @@
           [ 38.721522,
             14.125005 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5579",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5579",
           "name" : "Aksum",
           "desc" : "\"A kingdom in northern Ethiopia that converted to Christianity in the early 4th century. Joh. Eph., EH 4.53, holds that the inhabitants of Aksum adhered to the doctrines of Julian of Halicarnassus in the later sixth century.\"",
           "type" : "state" } },
@@ -429,7 +429,7 @@
           [ 32.6486095674,
             36.8834754557 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2799",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/2799",
           "name" : "Isauria — ܐܝܣܘܪܝܐ",
           "desc" : "\"A mountainous region of southern Anatolia known for its warlike and often rebellious population.\"",
           "type" : "region" } },
@@ -441,7 +441,7 @@
           [ 41.038876,
             38.263455 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5578",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5578",
           "name" : "Akbas - ܐܩܒܐ",
           "desc" : "\"Akbas was a Persian fortress on the river Batman close to Martyropolis in southern Armenia. Joh. Eph., EH 6.36, describes its capture and destruction by the Romans in 583.\"",
           "type" : "fortification" } },
@@ -453,7 +453,7 @@
           [ 30.7201762118,
             40.5628578119 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5587",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5587",
           "name" : "Bithynia - ܒܝܬܘܢܝܐ",
           "desc" : "\"A region and Roman province in north-western Asia Minor.\"",
           "type" : "region" } },
@@ -465,7 +465,7 @@
           [ 40.641398,
             38.839058 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5593",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5593",
           "name" : "Citharizon - ܩܝܬܪܝܙ",
           "desc" : "\"A fortress in the Roman part of Armenia close to Theodosiopolis and Persarmenia. Joh. Eph., EH 6.14, mentions this place.\"",
           "type" : "fortification" } },
@@ -477,7 +477,7 @@
           [ 32.884252,
             24.025031 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5626",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5626",
           "name" : "Philae - ܦܝܠܘܢ",
           "desc" : "\"Located on an island in the First Nile Cataract, Philae was a major cultic centre for the goddess Isis. Traces have been unearthed that pagan rituals took place there until the mid-5th century, yet already since the early 4th century, Philae was also an episcopal see.\"",
           "type" : "settlement" } },
@@ -489,7 +489,7 @@
           [ 35.228586,
             32.331417 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5636",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5636",
           "name" : "Samaria - ܫܡܪܝܢ",
           "desc" : "\"Situated to the north of Jerusalem, Samaria formed the core of the ancient kingdom of Israel. Its inhabitants, the Samaritans, preserved their religious customs in Late Antiquity and repeatedly revolted against the Roman Empire in the sixth century. Joh. Eph., EH 2.29, polemically establishes a connection between Samaritans and persecutors of Christians.\"",
           "type" : "region" } },
@@ -501,7 +501,7 @@
           [ 7.5,
             32.5 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/3051",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/3051",
           "name" : "Africa — ܐܦܪܝܩܐ",
           "desc" : "\"Roman Africa was centred around its capital Carthage and one of the richest and most fertile regions of the empire.\"",
           "type" : "province" } },
@@ -513,7 +513,7 @@
           [ 34.7425505,
             43.0786852 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/503",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/503",
           "name" : "Black Sea — ܝܡܐ ܐܘܟܡܐ",
           "desc" : "A large sea north of Anatolia. Attestation of name بحر بنْطُس in the Muʿjam al-buldān of Yāqūt al-Ḥamawī.",
           "type" : "open-water" } },
@@ -525,7 +525,7 @@
           [ 36.1378635,
             36.1336355 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5597",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5597",
           "name" : "Daphne - ܕܦܢܐ",
           "desc" : "\"Daphne was an opulent western suburb of Antioch. There were large residential areas and a number of important churches.\"",
           "type" : "settlement" } },
@@ -537,7 +537,7 @@
           [ 41.453009,
             38.04186 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5583",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5583",
           "name" : "Aphum - ܦܘܡ",
           "desc" : "\"Aphum was a fortification in the Roman-Persian border area in southern Armenia to the east of Martyropolis and the river Batman. Joh. Eph., EH 6.34, records that Maurice conquered it from the Persians in 578.\"",
           "type" : "fortification" } },
@@ -549,7 +549,7 @@
           [ 31.4591482445,
             16.1010829332 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/715",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/715",
           "name" : "Egypt",
           "desc" : "\"The region around the Nile valley, one of the richest and most fertile parts of the Roman Empire.\"",
           "type" : "region" } },
@@ -561,7 +561,7 @@
           [ 35.75,
             39.25 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2763",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/2763",
           "name" : "Cappadocia — ܩܦܘܕܩܝܐ",
           "desc" : "\"A region of central Anatolia which was subdivided in several provinces in Late Antiquity.\"",
           "type" : "region" } },
@@ -573,7 +573,7 @@
           [ 30.9479600355,
             36.921937827 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/1531",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/1531",
           "name" : "Pamphylia — ܦܡܦܝܠܝܐ",
           "desc" : "\"A region in the south of Asia minor, between Lycia and Cilicia.\"",
           "type" : "region" } },
@@ -585,7 +585,7 @@
           [ 32.6288214881,
             35.0444470024 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/714",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/714",
           "name" : "Cyprus — ܩܘܦܪܘܣ",
           "desc" : "\"An island in the eastern Mediterranean, Cyprus was organised as a Roman province.\"",
           "type" : "island" } },
@@ -597,7 +597,7 @@
           [ 15.0772312333,
             47.1149830333 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5596",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5596",
           "name" : "Danube - ܕܘܢܒܝܣ ܢܗܪܐ",
           "desc" : "\"A river in central and south-eastern Europe, formerly known as the Istros. Joh. Eph., EH 6.24 and 31, mentions this river.\"",
           "type" : "river" } },
@@ -609,7 +609,7 @@
           [ 28.979938,
             41.008548 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5623",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5623",
           "name" : "The Patriarchal Palace of Constantinople - ܒܝܬ ܐܦܝܣܩܦܝܘܢ",
           "desc" : "\"The residence of the patriarchs of Constantinople was adjacent to Hagia Sophia and provided direct access to the south-western corner of the church. Joh. Eph., EH 1.18-29, mentions it as the place where he and other miaphysite bishops were imprisoned and forced to accept an edict of union with the Chalcedonians.\"",
           "type" : "building" } },
@@ -621,7 +621,7 @@
           [ 34.546334,
             31.661963 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/674",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/674",
           "name" : "Ascalon",
           "desc" : "A coastal city north of Gaza. Attestation of name عَسْقلان in the Muʿjam al-buldān of Yāqūt al-Ḥamawī.",
           "type" : "settlement" } },
@@ -633,7 +633,7 @@
           [ 29.662742,
             30.841158 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2819",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/2819",
           "name" : "Mar Menas — ܡܪܝ ܡܐܢܐ",
           "desc" : "\"A monastery and pilgrimage centre about 60 km south-west of Alexandria in the Mareotis region. During the 5th and 6th centuries, the monastery developed into one of the largest monastery complexes in Egypt.\"",
           "type" : "monastery" } },
@@ -645,7 +645,7 @@
           [ 35.21667,
             31.78333 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/104",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/104",
           "name" : "Jerusalem — ܐܘܪܫܠܡ",
           "desc" : "\"As the birthplace of Christianity and the main destination of pilgrimage, Jerusalem played an important role for Christians of all Syr. traditions. 301. Jerusalem\"",
           "type" : "settlement" } },
@@ -657,7 +657,7 @@
           [ 28.979938,
             41.008548 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5609",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5609",
           "name" : "Hagia Sophia (Great Church) - ܥܕܬܐ ܪܒܬܐ",
           "desc" : "\"The monumental main church of Constantinople was destroyed during the Nika riots in 532, then rebuilt by Justinian on an even greater scale. Known as the Great Church, it played a major role in imperial ceremonies throughout the Byzantine period.\"",
           "type" : "church" } },
@@ -669,7 +669,7 @@
           [ 36.398,
             35.418 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/11",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/11",
           "name" : "Apamea — ܐܘܦܡܝܐ",
           "desc" : "\"One of the earliest Hellenistic city foundations in Syria, Apamea, situated on the Orontes ca. 90 km. south of Antioch, from the 2nd cent. onwards was an important center of Middle- and Neo-Platonist philosophy. 38. Apamea ܡܕܝܢܬܳܐ ܗܘܳܬ ܪܰܒܬܐ ܕܰܠܓܰܪܒܰܝ ܡܰܕܢܰܚ ܚܡܳܬ ܘܚܰܪܝܒܳܐ ܗܳܫܐ ܘܡܶܬܐܶܡܰܪ ܠܗ̇ ܩܰܠܥܗ̈ ܐܠܡܨ̇ܝܩ. مدينة كانت كبيرة في الشمال الشرقي من حماة وهي الآن خربة يقال لها قلعة المضيق once a large city northeast of Ḥama, it is now in ruins and is called Qalʿat al-Madīq.\"",
           "type" : "settlement" } },
@@ -681,7 +681,7 @@
           [ 35.231567,
             31.773417 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5621",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5621",
           "name" : "Nea Theotokos monastery - ܕܝܪܐ ܚܕܬܐ",
           "desc" : "\"The monumental complex of the Nea Church in Jerusalem, dedicated to the Mother of God, included a monastery and was founded by Justinian in 543. Joh. Eph., EH 1.32, mentions that Photius, stepson of Belisarius, was abbot of the monastery belonging to the church.\"",
           "type" : "monastery" } },
@@ -693,7 +693,7 @@
           [ 32.680833,
             15.523889 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5580",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5580",
           "name" : "Alodia",
           "desc" : "\"Alodia was a Nubian kingdom located to the south of Nobadia and Makouria. Joh.Eph., EH 4.48-53, narrates the missionary work of the miaphysite bishop Longinus there in the late 570s. In 4.53 and 55, John adds that Alodia was also known under the name Ethiopia (ܐܬܝܘܦܝܐ).\"",
           "type" : "state" } },
@@ -705,7 +705,7 @@
           [ 45.8,
             14.9 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/716",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/716",
           "name" : "Arabia",
           "desc" : "\"A region beyond the south-eastern borders of the Roman Empire, parts of it were incorporated in the empire and formed a province of the same name.\"",
           "type" : "region" } },
@@ -717,7 +717,7 @@
           [ 28.159216,
             38.746057 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/1526",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/1526",
           "name" : "Lydia — ܠܘܕܝܐ",
           "desc" : "A region of Asia Minor.",
           "type" : "region" } },
@@ -729,7 +729,7 @@
           [ 44.9405753712,
             32.8503500814 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/717",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/717",
           "name" : "Beth Aramaye",
           "desc" : "\"The Syriac name \"the Land of the Arameans\" corresponded to the Persian province of Asorestan in central Mesopotamia, the region around Babylon.\"",
           "type" : "region" } },
@@ -741,7 +741,7 @@
           [ 27.641374,
             42.555937 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5581",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5581",
           "name" : "Anchialus - ܐܢܟܝܠܘܣ",
           "desc" : "\"Anchialus, modern Pomorie in Bulgaria, was a city in Thrace on the west coast of the Black Sea.\"",
           "type" : "settlement" } },
@@ -753,7 +753,7 @@
           [ 28.9425,
             41.0383 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5620",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5620",
           "name" : "Mary of Blachernai (church) - ܒܝܬ ܡܪܬܝ ܡܪܝܐ ܕܒܠܩܪܢܐ",
           "desc" : "\"A church in north-western Constantinople. Joh. Eph., EH 2.16, mentions a priest named Comitas who was part of the clergy of this church.\"",
           "type" : "church" } },
@@ -765,7 +765,7 @@
           [ 39.5,
             37.5 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/1452",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/1452",
           "name" : "Mesopotamia — ܒܝܬ ܢܗܪ̈ܝܢ",
           "desc" : "The watershed of the Tigris and Euphrates rivers, including southeastern Turkey, northeastern Syria, all of Iraq, and western Iran. Attestation of name جزيرة اقور in the Muʿjam al-buldān of Yāqūt al-Ḥamawī. This place shares a name with one or more distinct places. This place shares a location with one or more distinct places that should not be confused with one another.",
           "type" : "region" } },
@@ -777,7 +777,7 @@
           [ 36.15,
             36.2 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/10",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/10",
           "name" : "Antioch — ܐܢܛܝܘܟܝܐ",
           "desc" : "\"City in the historical region of Syria (today in Turkey). 36. Antioch\"",
           "type" : "settlement" } },
@@ -789,7 +789,7 @@
           [ 23.726464,
             37.971687 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/677",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/677",
           "name" : "Athens",
           "desc" : "A city in Greece.",
           "type" : "settlement" } },
@@ -801,7 +801,7 @@
           [ 41.003257,
             38.1427855 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/134",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/134",
           "name" : "Maypherqaṭ — ܡܝܦܪܩܛ",
           "desc" : "\"ܛܒܝܒܳܐ ܗܘܳܬ ܕܰܡܕܝܢ̈ܬܳܐ ܕܐܳܡܺܝܕ ܠܓܰܪܒܰܝ ܡܰܕܢܚܳܗ̇ ܘܝܰܘܡܳܢ ܩܰܣܛܪܰܐ ܗܝ̣. كانت اشهر مدينة بديار بكر في شماليها الشرقي وهي الان بليدة. once the most famous city in the northeastern part of the province of Diyarbakir, now a small town.\"",
           "type" : "settlement" } },
@@ -813,7 +813,7 @@
           [ 27.952973,
             40.971013 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5611",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5611",
           "name" : "Heraclea (Perinthus) - ܗܪܩܠܝܐ",
           "desc" : "\"Metropolis of the Late Roman province Europa in Thrace, its significance dwindled in Late Antiquity because of the rise of Constantinople which was located only 90km to the east. Joh. Eph., EH 1.9, mentions it as a place of exile for miaphysites.\"",
           "type" : "settlement" } },
@@ -825,7 +825,7 @@
           [ 41.145452,
             38.085361 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5639",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5639",
           "name" : "Semkhart - ܫܡܟܪܬ",
           "desc" : "\"According to Joh. Eph., EH 6.35, Maurice, as commander of the Roman forces in the east, erected a fortress called Semkhart next to a mountain with the same name in the Armenian region of Sophanene in the early 580s. The place is called Samocharta in the Greek sources.\"",
           "type" : "fortification" } },
@@ -837,7 +837,7 @@
           [ 30.261111,
             41.216111 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5598",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5598",
           "name" : "Daphnudium - ܕܦܢܘܕܝܢ",
           "desc" : "\"This settlement, mentioned in Joh. Eph., EH 3.8, as the place of origin of Ino Anastasia, is tentatively identified with the island of Daphnusia off the Black Sea coast of Bithynia.\"",
           "type" : "settlement" } },
@@ -849,7 +849,7 @@
           [ 28.975,
             41.003 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2793",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/2793",
           "name" : "Hormisda — ܗܘܪܡܙܕܐ",
           "desc" : "\"An imperial palace in Constantinople, built in the 5th century directly to the south-west of the Great Palace.\"",
           "type" : "building" } },
@@ -861,7 +861,7 @@
           [ 28.040286,
             38.488314 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5638",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5638",
           "name" : "Sardis - ܣܪܕܐ",
           "desc" : "\"The capital of Lydia, Sardis was one of the most important cities in Asia Minor throughout Antiquity and into the Byzantine period.\"",
           "type" : "settlement" } },
@@ -873,7 +873,7 @@
           [ 28.876487,
             40.976033 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5610",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5610",
           "name" : "Hebdomon - ܐܒܕܡܘܢ",
           "desc" : "\"The Hebdomon was a coastal suburb located seven miles to the west of Constantinople. In Late Antiquity, it possessed an important imperial residence and large parade grounds for the army, hence it was also referred to in Greek as πρόκενσον (prokenson). Emperors were, upon their accession, acclaimed by the army on the parade ground of the Hebdomon in the later fourth and fifth centuries.\"",
           "type" : "settlement" } },
@@ -885,7 +885,7 @@
           [ 39.016667,
             35.95 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/109",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/109",
           "name" : "Kallinikos — ܩܐܠܘܢܝܩܝ",
           "desc" : "\"ܡܕܝܢܬܳܐ ܗܘܳܬ ܪܰܒܬܳܐ ܒܩܘܪܒܳܐ ܕܰܦܪܳܬ ܘܡܶܬܰܐܡܪ ܠܗ̇ ܪܰܩܰܗ̈ ܘܝܰܘܡܳܢܐ ܗܘܳܬ ܡܕܝܢܬܳܘܢܺܝܬܳܐ ܕܕܳܡܝܳܐ ܠܰܩܪܺܝܬܳܐ. وهي قالونيقس القديمة مدينة عظيمة واقعة بقرب الفرات واليوم امست بليدة اشبه بالقرية. the ancient Callinicus, it was a big city near the Euphrates. Today it is a small town, more nearly a village.\"",
           "type" : "settlement" } },
@@ -897,7 +897,7 @@
           [ 41.2757333333,
             39.908079 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/484",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/484",
           "name" : "Erzurum — ܐܪܙܪܘܡ",
           "desc" : "\"An important garrison town on the eastern border, the city was founded by Theodosius II in the first half of the 5th century. Its fortifications were further enlarged by Anastasius and Justinian, and it was the residence of the Roman military commander of Armenia. Joh. Eph., EH 2.20, mentions the patricius Justinian, a cousin of Justin II, in this role in the early 570s.\"",
           "type" : "settlement" } },
@@ -909,7 +909,7 @@
           [ 27.5,
             37.5 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2747",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/2747",
           "name" : "Asia — ܐܣܝܐ",
           "desc" : "\"A civil diocese in the western part of Anatolia, also the name of a Roman province.\"",
           "type" : "region" } },
@@ -921,7 +921,7 @@
           [ 28.9771394,
             41.0064179667 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5607",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5607",
           "name" : "Great Palace of Constantinople - ܦܠܛܝܢ",
           "desc" : "\"The Great Palace was the residential complex of the East Roman emperors throughout Late Antiquity. Located at the south-eastern end of Constantinople, it consisted of several palaces and witnessed continuous building activity.\"",
           "type" : "building" } },
@@ -933,7 +933,7 @@
           [ 38.31463,
             38.34767 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/136",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/136",
           "name" : "Melitene — ܡܝܠܝܛܝܢܝ",
           "desc" : "\"City in eastern Anatolia, located near the right bank of the Euphrates and to the north of the main range of the Eastern Taurus. 367. Melitene ܡܕܝܢܬܳܐ ܗܝ ܪܰܒܬܳܐ ܘܰܛܒܝܒܳܐ ܗܘܳܬ ܕܕܘܟܬܳܗ̇ ܩܰܪܝܒܳܐ ܗܝ ܠܢܰܗܪܳܐ ܕܰܦܪܳܬ ܥܰܠ ܣܶܦܬܗ ܕܝܰܡܝܢܳܐ. ܡܶܢ ܐܶܡܗ̈ܬܳܐ ܕܰܡܕܝܢ̈ܬܳܐ ܕܣܘܪ̈ܝܝܶܐ ܐܝܬ ܗܘܳܐ ܠܗܘܢ ܒܳܗ̇ ܫܶܬ ܘܚܰܡܫܝܢ ܥܕ̈ܬܳܐ 1049 ܘܡܳܬܳܐ ܗܝ ܕܰܓܒܰܝ̈ܐ ܕܪ̈ܝܫܳܢܐ ܕܝܰܕܘܥ̈ܬܳܢܰܝܗܘܢ مدينة في ولاية معمورة العزيز كانت مشهورة عظيمة مذكورة واقعة قريبا من نهر الفرات على الضفة اليمنى منه، من امهات مدن السريان كان لهم فيها ست وخمسون بيعة سنة 1049 م. وهي موطن نخبة من اقطاب علمائهم وائمتهم امست اليوم بليدة. a city in the province of Maʿmurat al-ʿAzīz, near the Euphrates. In the past it was large and famous. It was one of the largest centers of the Syrians, who in 1049 had fifty-six churches there. It was also the birthplace of a number of Syrian learned men. Today it is a small town. (See the biography of Christodolus by Michael, Coptic bishop of Tinnis [d. 1069], in Assemani’s “Confession of the Fathers,” Bibliotheca Orientalis, 2: 145-152, and in the Coptic Patriarchal Library).\"",
           "type" : "settlement" } },
@@ -945,7 +945,7 @@
           [ 30.7425,
             18.224444 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5617",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5617",
           "name" : "Makouria",
           "desc" : "\"A kingdom located in Nubia, situated between the kingdoms of Nobadia and Alodia. Joh. Eph., EH 4.51 and 53, speaks of the people of Makouria.\"",
           "type" : "state" } },
@@ -957,7 +957,7 @@
           [ 36.73369977389633,
             36.13024487311365 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5575",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5575",
           "name" : "Bassos, Monastery of Mar - ܕܝܪܐ ܕܡܪܝ ܒܣ",
           "desc" : "\"This monastery was located in north-western Syria, about 30 km from Chalcis. The miaphysite bishop John of Chalcis probably resided there, as is recorded in Joh. Eph., EH 4.10.\"",
           "type" : "monastery" } },
@@ -969,7 +969,7 @@
           [ 28.7237779096,
             37.7085832624 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2742",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/2742",
           "name" : "Aphrodisias — ܐܦܪܘܕܝܣܝܕܐ",
           "desc" : "\"The metropolis of the province of Caria in south-western Anatolia.\"",
           "type" : "settlement" } },
@@ -981,7 +981,7 @@
           [ 37.017879,
             39.747662 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/1504",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/1504",
           "name" : "Sivas — ܣܝܘܐܣ",
           "desc" : "\"Sebasteia, modern Sivas, was the metropolis of the late Roman province of Armenia prima. In 575\/6, it was sacked by a Persian army under Khosrow himself, as recorded in Joh. Eph., EH 6.8.\"",
           "type" : "settlement" } },
@@ -993,7 +993,7 @@
           [ 35.82794385,
             40.66680835 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/292",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/292",
           "name" : "Amāsiyya — ܐܡܐܣܝܐ",
           "desc" : "\"The capital of the province Helenopontus, Amaseia was the see of a metropolitan and an important center in Late Antique Asia Minor. ܡܕܝܢܬܐ ܕܥܠ ܣܦܬ ܢܰܗܪܐ ܕܝܶܫܺܝܠ ܐܺܝܪܡܰܐܩ ܘܰܒܬܰܝܡܢܗ̇ ܕܨܰܐܡܨܘܽܢ ܡܪܰܕܶܐ 50 ܡܝ̈ܠܐ. مدينة على ضفة نهر يشيل ايرماق على مسافة 50 ميلاً من جنوبي سمسون a town fifty miles south of Samsun, on the bank of Yeşil Irmak.\"",
           "type" : "settlement" } },
@@ -1005,7 +1005,7 @@
           [ 40.25866,
             37.329794 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5574",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5574",
           "name" : "Tell Beshme - ܬܠܒܫܡܐ",
           "desc" : "\"A town in Roman Mesopotamia. Its surroundings were pillaged by the Persians under Adarmahan in the 570s, as recorded in Joh. Eph., EH 6.13.\"",
           "type" : "settlement" } },
@@ -1017,7 +1017,7 @@
           [ 44.58079045,
             40.01185995 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5602",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5602",
           "name" : "Dvin - ܕܐܘܝܢ",
           "desc" : "\"Founded in the 4th century, Dvin was the capital of Armenia. After the loss of the Armenian independence and the partition of the region between Rome and the Sasanian Empire, Dvin became the residence of the Sasanian governor of Persarmenia. Joh. Eph., EH 2.18-22, deals with the Sasanian persecution of the Armenian Christians that took place there in the early 570s.\"",
           "type" : "settlement" } },
@@ -1029,7 +1029,7 @@
           [ 12.4861685,
             41.8917375 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/641",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/641",
           "name" : "Rome — ܪܘܡܝ",
           "desc" : "The capital city of Italy and formerly the capital of the Roman Empire. Attestation of name رومية in the Muʿjam al-buldān of Yāqūt al-Ḥamawī. This place shares a name with one or more distinct places.",
           "type" : "settlement" } },
@@ -1041,7 +1041,7 @@
           [ 26.473596095,
             30.8892199489 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2810",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/2810",
           "name" : "Libya — ܠܘܒܐ",
           "desc" : "\"The region of northern Africa to the east of Egypt, including the Cyrenaica.\"",
           "type" : "region" } },
@@ -1053,7 +1053,7 @@
           [ 27.1973335804,
             36.9917589062 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5628",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5628",
           "name" : "Plateia - ܦܠܛܝܐ",
           "desc" : "\"The modern Yassiada, in Greek called Plate or Plateia. This is one of the Princes' Islands close to Constantinople where recalcitrant clerics were frequently sent into exile in Late Antiquity and the Byzantine period. Joh. Eph., EH 1.16, notes that the miaphysite bishop Stephen of Cyprus was maltreated there.\"",
           "type" : "island" } },
@@ -1065,7 +1065,7 @@
           [ 27.425929777,
             37.0370402584 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/1472",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/1472",
           "name" : "Caria — ܩܐܪܝܐ",
           "desc" : "A region of western Anatolia",
           "type" : "region" } },
@@ -1077,7 +1077,7 @@
           [ 28.9746077,
             41.005444 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5614",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5614",
           "name" : "Hippodrome of Constantinople - ܐܦܝܩܘܣ",
           "desc" : "\"The great hippodrome of Constantinople was situated directly adjacent to the imperial palace. This was one of the few places where the people could interact with the emperor via acclamations.\"",
           "type" : "building" } },
@@ -1089,7 +1089,7 @@
           [ 37.8712745,
             28.5482213 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2740",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/2740",
           "name" : "Antioch in Caria — ܐܢܛܝܘܟ ܕܩܪܝܐܐ",
           "desc" : "\"A city in Caria in south-western Anatolia, also known as Antioch on the Maeander. John of Ephesus, EH 1.14 records that Paul of Aphrodisias was made bishop there after embracing the council of Chalcedon.\"",
           "type" : "settlement" } },
@@ -1101,7 +1101,7 @@
           [ 29.082797,
             41.106759 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5577",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5577",
           "name" : "Acoemetae, Monastery of the - ܕܝܪܐ ܕܐܩܝܡܛܘܢ",
           "desc" : "\"Famous for their perpetual worship, the movement of the Acoemetae (sleepless monks), founded at the start of the 5th century, eventually settled in a monastery on the Asian side of the Bosphorus. The monks were staunchly dyophysite, to such an extent that they were suspected of harbouring Nestorian sympathies and condemned in the early 530s. Nevertheless, their monastery remained important and served as a place of imprisonment for miaphysite clerics, as is mentioned in Joh. Eph., EH 1.17.\"",
           "type" : "monastery" } },
@@ -1113,7 +1113,7 @@
           [ 41.384722,
             37.973889 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/285",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/285",
           "name" : "Arzun — ܐܪܙܘܢ",
           "desc" : "\"Arzun was the capital of the Armenian districut of Arzanene on the border zone between the Armenian highlands and upper Mesopotamia. Joh. Eph., EH 6.34, records the Roman conquest of the city in the early 580s. ܡܕܝܺܢܬܐ ܪܒܬܐ ܕܢܳܦܠܐ ܠܓܰܪܒܰܝ ܡܰܥܪܰܒ ܣܥܶܪܬ ܚܰܪ̈ܒܳܬܗ̇ ܩܝ̈ܡܳܢ مدينة كبيرة كانت شمالي غربي سعرت اطلالها ماثلة a large city, formerly northwest of Seʿert. Its ruins can still be seen.\"",
           "type" : "settlement" } },
@@ -1125,7 +1125,7 @@
           [ 35.21639,
             33.26889 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/195",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/195",
           "name" : "Tyros",
           "desc" : "An important port city of the eastern Mediterranean Sea west of Damascus. Attestation of name صُوْر in the Muʿjam al-buldān of Yāqūt al-Ḥamawī.",
           "type" : "settlement" } },
@@ -1137,7 +1137,7 @@
           [ 41.21667,
             37.06667 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/142",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/142",
           "name" : "Nisibis — ܢܨܝܒܝܢ",
           "desc" : "\"City in Mesopotamia and important center of early Syriac Christianity. 400. Nisibis ܡܕܝܢܬܳܐ ܕܥܰܡܝܪܳܐ ܡܶܢ ܐܰܬܪ̈ܘܳܬܳܐ ܕܰܓܙܝܳܪܐ. ܐܝܬ ܒܶܝܬ ܠܳܗ̇ ܠܡܰܘܨܠ ܚܰܡܫܳܐ ܝܰܘܡ̈ܝܢ. ܘܝܰܘܡܳܢܳܐ ܐܺܝܬܶܝܗ̇ ܡܕܝܢܳܬܘܢܝܬܳܐ ܘܐܝܬ ܬܽܘܒ ܢܨܝܒܝܢ ܩܪܝܬܳܐ ܕܥܰܠ ܣܶܦܰܬ ܦܪܳܬ ܠܡܰܥܪܒܳܐ ܕܒܺܝܪܰܗܓܺܝܟ ܘܡܶܬܝܰܕܥܳܐ ܢܨܺܝܒܝܢ ܕܪ̈ܘܡܳܝܐ. مدينة عامرة من بلاد الجزيرة بينها وبين الموصل خمسة ايام وهي اليوم بليدة: ونصيبين ايضا قرية على شاطئ الفرات غربي بيرهجك كانت تعرف بنصيبين الروم. a town in the Jazira, five days’ journey from Mosul; today it is a small town. Nisibin is also the name of a village on the west bank of the Euphrates, west of Biricik, formerly known as the Byzantine Nisibin. [Modern name, Nusaybin. (tr.)]\"",
           "type" : "settlement" } },
@@ -1149,7 +1149,7 @@
           [ 35.75,
             37.25 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/55",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/55",
           "name" : "Cilicia — ܩܝܠܝܩܝܐ",
           "desc" : "An Anatolian coastal region north of Antioch.",
           "type" : "region" } },
@@ -1161,7 +1161,7 @@
           [ 28.979938,
             41.008548 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/586",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/586",
           "name" : "Constantinople — ܩܘܣܛܢܛܝܢܘܦܘܠܝܣ",
           "desc" : "The capital of the Byzantine Empire. Attestation of names قسطنطينية and اصطنْبُوْل in the Muʿjam al-buldān of Yāqūt al-Ḥamawī. This place shares a name with one or more distinct places. This place shares a location with one or more distinct places that should not be confused with one another.",
           "type" : "settlement" } },
@@ -1173,7 +1173,7 @@
           [ 36.483333,
             32.516667 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/40",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/40",
           "name" : "Bostra — ܒܘܨܪ",
           "desc" : "\"City in the Ḥawrān, present-day southern Syria, ca. 120 fan. south of Damascus. 112. Bostra ܡܕܺܝܬܘܽܢܳܝܬܐ ܒܚܰܘܪܢ ܘܡܶܬܐܶܡܰܪ ܠܗ̇ ܒܰܨܪܺܝ ܐܰܣܟܺܝ ܫܶܐܡ بليدة في حوران ويقال لها بُصرى اسكي شام a small town in Ḥawrān, now called Eski Shām.\"",
           "type" : "settlement" } },
@@ -1185,7 +1185,7 @@
           [ 27.339722,
             37.941944 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/623",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/623",
           "name" : "Ephesus — ܐܦܣܘܣ",
           "desc" : "\"A city in western Asia Minor.\"",
           "type" : "settlement" } },
@@ -1197,7 +1197,7 @@
           [ 38.8,
             37.15 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/78",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/78",
           "name" : "Edessa — ܐܘܪܗܝ",
           "desc" : "\"183. Edessa ܡܕܺܝܢܬܐ ܗܳܝ ܛܒܝܒܬܳܐ ܠܡܰܕܢܚܳܐ ܕܚܳܠܳܒ ܚܰܡܫܳܐ ܝܰܘܡ̈ܝܢ ܘܡܶܫܬܰܡܗܐ ܝܰܘܡܳܢ ܐܘܪܦܰܗ̈ مدينة مشهورة خمسة ايام عن حلب شرقا وتسمى اليوم اورفه. a famous city, five day journey eastward from Aleppo, now called Urfa. five day journey eastward from Aleppo \"",
           "type" : "settlement" } },
@@ -1209,7 +1209,7 @@
           [ 41.5385,
             37.321778 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/226",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/226",
           "name" : "Mor Gabriel — ܕܝܪܐ ܕܩܪܛܡܝܢ",
           "desc" : "\"The Monastery of Qarṭmin began long before its official foundation date of 397. 214. Gabriel, Monastery of Mor ܠܡܰܕܢܚܐ ܕܡܶܕܝܰܕ ܡܰܪܕܶܐ ܐܰܪܒܰܥ ܫܳܥ̈ܝܢ ܗܽܘܝܽܘ ܛܒܺܝܒܶܐ ܕܕܰܝܪ̈ܳܬܳܐ ܕܛܘܪܥܰܒܕܝܢ. ܒܢܰܐܘܽܗܝ ܥܶܢܘܳܝ̈ܐ ܡܳܪܝ ܫܡܘܐܝܠ ܘܡܳܪܝ ܫܶܡܥܘܢ. ܫܢܰܬ 397 ܒܳܬܰܪܟܶܢ ܐܶܫܬܕܰܪ ܥܠܰܘܗܝ ܫܶܡ ܪܝܫܗ ܘܐܶܦܝܣܩܘܦܗ ܡܳܪܝ ܓܰܒܪܐܝܠ 667 ܘܰܗܘܳܐ ܟܘܪܣܝܳܐ ܠܡܶܛܪ̈ܘܦܘܠܝܛܐ ܕܛܘܽܪܥܰܒܕܺܝܢ. ܫܢܰܬ 615 ܥܕܰܡܐ ܠܰܫܢܬ 1049 ܟܶܢ ܐܶܬܒܰܠܚܕ ܒܪܝܺܫܳܢܘܬ ܦܶܠܓܘܬܐ ܪܘܺܝܚܬܐ ܕܛܘܪܳܐ. ܘܰܠܚܰܪܬܐ ܐܶܣܬܰܝܟ ܒܡܰܪܥܝܬܐ ܕܝܠܳܢܳܝܬܐ ܥܕܰܡܐ ܠܰܫܢܰܬ 1915 ܐܶܬܢܰܦܰܩܘ ܒܗ ܐܰܪܒܥܐ ܦܰܛܪ̈ܝܪܟܐ ܘܚܕ ܡܰܦܪܝܢܐ ܘܬܶܫܥܐ ܘܫܰܒܥܝܢ ܐܶܦܝܣܩܘ̈ܦܐ ܘܰܥܕܰܟܝܠ ܥܰܡܝܪ ܘܰܡܝܰܬܰܒ. شرقي مذيات مسيرة اربع ساعات عنها اشهر اديار طورعبدين، بناه الناسكان مار صموئيل ومار شمعون عام 397 ثم اطلق عليه اسم رئيسه واسقفه مار جبرائيل 667 + صار كرسيا لمطارنة طورعبدين سنة 615 حتى 1049 ثم انفرد مطرانه برئاسة قسم واسع من الجبل ثم انحصر بابرشية خاصة به حتى سنة 1915 تخرج فيه اربعة بطاركة ومفريان وتسعة وسبعون اسقفاً لا يزال عامرا آهلا. four hour journey east of Midyat, is the most famous monastery in Tur ʿAbdin. It was built in 397 by the two ascetics, St. Samuel and St. Simon. It is commonly called the Monastery of St. Gabriel, after its abbot and bishop Gabriel (d. 667). This monastery was the metropolitan see of Tur ʿAbdin from 615 to 1049. Afterwards, its metropolitan was the ecclesiastical leader of a large part of Tur ʿAbdin; still later, however, his jurisdiction was restricted to a private diocese until 1915. This monastery claims four Patriarchs, a Maphryono and seventy bishops. It is still inhabited.\"",
           "type" : "monastery" } },
@@ -1221,7 +1221,7 @@
           [ 28.975833,
             41.006389 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/5649",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/5649",
           "name" : "Zeuxippus, Baths of - ܙܘܩܣܦܘܣ",
           "desc" : "\"Situated very close to the Great Palace, Hagia Sophia and the hippodrome, the baths of Zeuxippus were the most famous public baths of Constantinople. Throughout Late Antiquity, emperors brought statues and other renowned works of art to Constantinople, many of which were put on display in the baths of Zeuxippus. The baths were burned down in 532 during the Nika riots and rebuilt by Justinian I. Joh. Eph., EH 3.24, refers to the eastern part of the city near the seashore by the name Zeuxippus, likely because of the prominence of the baths.\"",
           "type" : "building" } },
@@ -1233,7 +1233,7 @@
           [ 29.025789,
             40.983393 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/622",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/622",
           "name" : "Chalcedon — ܟܠܩܝܕܘܢܐ",
           "desc" : "A city across the Bosphorus from Constantinople.",
           "type" : "settlement" } },
@@ -1245,7 +1245,7 @@
           [ 38.47134,
             37.56452 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/178",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/178",
           "name" : "Samosata — ܫܡܝܫܛ",
           "desc" : "\"ܐܰܬܪܐ ܗܘ ܕܰܠܡܰܥܪܒܗ ܕܰܦܪܳܬ ܘܰܠܓܰܪܒܝܗ ܕܐܘܪܗܳܝ. بلدة على غربي الفرات شمالي الرها. a town on the Euphrates, north of Edessa.\"",
           "type" : "settlement" } },
@@ -1257,7 +1257,7 @@
           [ 38.847326,
             35.8808455 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/185",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/185",
           "name" : "Shura",
           "desc" : "\"Shura was a fortress town in the province of Syria Euphratensis west of Callinicum.\"",
           "type" : "settlement" } },
@@ -1269,7 +1269,7 @@
           [ 44.44985,
             31.88332 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/219",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/219",
           "name" : "Ḥirta — ܚܐܪܬܐ",
           "desc" : "\"Ancient city near the Euphrates to the southeast of present-day al-Najaf. 262. Ḥirta ܡܕܺܝܢܬܳܐ ܗܝ ܥܰܬܝܩܬܳܐ ܕܪܰܚܝܼܩܐ ܗܘܳܬ ܡܢ ܟܽܘܦܰܗ ܬܠܳܬܐ ܡܝ̣̈ܠܐ ܠܡܰܕܢܚܳܐ ܕܢܰܓܦ. مدينة قديمة دائرة كانت على ثلاثة اميال من الكوفة شرقي النجف an ancient city, three miles from Kufa and east of al-Najaf.\"",
           "type" : "settlement" } },
@@ -1281,7 +1281,7 @@
           [ 22.8799302264,
             37.9072987541 ] },
         "properties" : 
-        { "uri" : "http:\/\/syriaca.org\/place\/2657",
+        { "uri" : "http:\/\/dev.syriaca.org\/johnofephesus\/places\/2657",
           "name" : "Corinth — ܩܘܪܝܢܬܘܣ",
           "desc" : "\"Located at the entrance to the Peloponnese, Corinth was the metropolis of the Roman province of Achaea.\"",
           "type" : "settlement" } } ] }


### PR DESCRIPTION
These are hardcoded. So for production they will have to be changed. This has to do with how AWS handles the links. I can not code them as relative links.