### PR TITLE
Add Chinese language tags to syriacaAll ODD

### DIFF
--- a/documentation/schemas/syriacaAll.odd
+++ b/documentation/schemas/syriacaAll.odd
@@ -257,6 +257,18 @@
                   <gloss>Turkish</gloss>
                   <desc>Turkish</desc>
                 </valItem>
+                <valItem ident="zh">
+                  <gloss>Chinese</gloss>
+                  <desc>Chinese</desc>
+                </valItem>
+                <valItem ident="zh-hans">
+                  <gloss>Chinese (Simplified)</gloss>
+                  <desc>Chinese (Simplified)</desc>
+                </valItem>
+                <valItem ident="zh-hant">
+                  <gloss>Chinese (Traditional)</gloss>
+                  <desc>Chinese (Traditional)</desc>
+                </valItem>
               </valList>
             </attDef>
           </attList>


### PR DESCRIPTION
@dlschwartz I've added in this branch the Chinese language codes that we use for place name variants (`@xml:lang`) to the syriacaAll ODD file. I don't know what's needed to run compiling and output of the RNG, so please go ahead and run those when you have a chance. And/or add it to the right spot if I screwed this up...Thanks!